### PR TITLE
Implement maxFaceArea for finer mesh subdivision

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,6 +21,8 @@ export interface Box {
     top?: string
   }
   projectionSubdivision?: number // Number of subdivisions per side for face projection (default: 2)
+  /** When set, faces will be subdivided until each triangle area is below this value */
+  maxFaceArea?: number
   // STL support
   stlUrl?: string
   stlRotation?: Point3

--- a/tests/__snapshots__/obj2.snap.svg
+++ b/tests/__snapshots__/obj2.snap.svg
@@ -100,12 +100,12 @@
     <polygon fill="rgba(39,39,39,1)" stroke="none" points="2,-14 2,-43 2,-43" />
     <polygon fill="rgba(39,39,39,1)" stroke="none" points="2,-14 2,-43 2,-14" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,10 2,-14 4,11" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="4,11 2,-14 25,-1" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="3,-8 2,-14 8,-11" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-3,-13 -2,-14 -5,6" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-2,-14 -3,-13 -3,-22" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-3,-22 -2,-43 -2,-14" />
     <polygon fill="rgba(39,39,39,1)" stroke="none" points="-2,-14 -2,-43 -2,-43" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,-14 2,-43 25,-1" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,-14 2,-21 8,-11" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-5,6 -8,-10 -3,-13" />
     <polygon fill="rgba(136,136,136,1)" stroke="none" points="-5,-20 -10,-18 -10,-18" />
     <polygon fill="rgba(136,136,136,1)" stroke="none" points="-5,-20 -10,-18 -5,-21" />
@@ -121,9 +121,14 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-37,36 -45,38 -39,34" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-37,36 -39,34 -37,33" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-37,33 -39,34 -39,32" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-1 -8,-10 -5,6" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-1 -39,-3 -8,-10" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-39,-3 -8,-19 -8,-10" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="3,-8 8,-11 8,-5" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-5 8,-11 13,-7" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,-21 8,-18 8,-11" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-11 8,-18 13,-7" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-16,-6 -8,-10 -7,-2" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-16,-6 -23,-7 -8,-10" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-23,-7 -8,-15 -8,-10" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,-21 2,-28 8,-18" />
     <polygon fill="rgba(174,174,174,1)" stroke="none" points="-5,-22 -10,-19 -9,-19" />
     <polygon fill="rgba(174,174,174,1)" stroke="none" points="-5,-22 -9,-19 -4,-22" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-3,-22 -5,-22 -4,-22" />
@@ -140,22 +145,38 @@
     <polygon fill="rgba(187,187,187,1)" stroke="none" points="-4,-22 -9,-19 -8,-19" />
     <polygon fill="rgba(187,187,187,1)" stroke="none" points="-4,-22 -8,-19 -3,-22" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-8,-19 -48,-20 -3,-22" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-3,-22 -48,-20 -2,-43" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-3,-22 -13,-22 -3,-27" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-10,-18 -10,-18 -10,-19" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-10,-19 -10,-18 -10,-19" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-8,-19 -9,-19 -10,-18" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-10,-18 -9,-19 -9,-19" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-10,-18 -9,-19 -10,-19" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-23,-11 -8,-15 -23,-7" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-23,-11 -8,-19 -8,-15" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-43,36 -43,39 -37,33" />
     <polygon fill="rgba(195,195,195,1)" stroke="none" points="-42,19 -43,36 -37,33" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-45,38 -43,39 -45,35" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="3,-2 3,-8 8,-5" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-5 13,-7 14,-1" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="14,-1 13,-7 19,-4" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-18 13,-15 13,-7" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="13,-7 13,-15 19,-4" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-25 13,-15 8,-18" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,-28 8,-25 8,-18" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,-28 2,-35 8,-25" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-13,-22 -13,-27 -3,-27" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-3,-27 -13,-27 -3,-32" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-45,35 -43,39 -43,36" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-45,35 -43,36 -49,22" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-39,-3 -48,-20 -8,-19" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-16,-15 -17,-19 -8,-19" />
     <polygon fill="rgba(123,123,123,1)" stroke="none" points="-49,21 -44,18 -43,19" />
     <polygon fill="rgba(123,123,123,1)" stroke="none" points="-49,21 -43,19 -49,22" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-42,19 -43,19 -42,19" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-42,19 -43,19 -44,18" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-16,-6 -7,-2 -15,3" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-1 -16,-6 -15,3" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-32,-2 -23,-7 -16,-6" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-1 -32,-2 -16,-6" />
     <polygon fill="rgba(130,130,130,1)" stroke="none" points="-50,20 -44,17 -44,18" />
     <polygon fill="rgba(130,130,130,1)" stroke="none" points="-50,20 -44,18 -49,21" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-42,19 -44,18 -42,19" />
@@ -170,22 +191,37 @@
     <polygon fill="rgba(150,150,150,1)" stroke="none" points="-49,19 -44,16 -50,20" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-42,19 -44,16 -42,18" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-42,18 -44,16 -43,16" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-13,-27 -13,-32 -3,-32" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-3,-32 -13,-32 -2,-37" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-5 14,-1 9,2" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="3,-2 8,-5 9,2" />
     <polygon fill="rgba(156,156,156,1)" stroke="none" points="-49,19 -46,14 -43,16" />
     <polygon fill="rgba(156,156,156,1)" stroke="none" points="-43,16 -46,14 -40,10" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-42,18 -43,16 -38,12" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-38,12 -43,16 -40,10" />
     <polygon fill="rgba(194,194,194,1)" stroke="none" points="-47,22 -42,19 -47,22" />
     <polygon fill="rgba(194,194,194,1)" stroke="none" points="-47,22 -42,19 -42,19" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="14,-1 19,-4 20,2" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="20,2 19,-4 25,-1" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="13,-15 19,-11 19,-4" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="19,-4 19,-11 25,-1" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-47,22 -42,19 -47,22" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-47,22 -42,19 -42,19" />
     <polygon fill="rgba(185,185,185,1)" stroke="none" points="-47,22 -42,19 -47,22" />
     <polygon fill="rgba(185,185,185,1)" stroke="none" points="-47,22 -42,19 -42,19" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-25 14,-22 13,-15" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="13,-15 14,-22 19,-11" />
     <polygon fill="rgba(180,180,180,1)" stroke="none" points="-47,22 -42,19 -47,22" />
     <polygon fill="rgba(180,180,180,1)" stroke="none" points="-47,22 -42,19 -42,18" />
     <polygon fill="rgba(177,177,177,1)" stroke="none" points="-38,12 -47,22 -42,18" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,-35 8,-32 8,-25" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-25 8,-32 14,-22" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,-35 2,-43 8,-32" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-49,22 -47,22 -49,21" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-49,21 -47,22 -47,22" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-49,21 -47,22 -50,20" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-13,-32 -13,-37 -2,-37" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-2,-37 -13,-37 -2,-43" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-50,20 -47,22 -47,22" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-50,20 -47,22 -50,20" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="44,41 43,44 39,45" />
@@ -193,14 +229,20 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="43,44 46,46 39,48" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="46,46 43,44 46,43" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="46,43 43,44 44,41" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-15,3 -7,-2 -5,6" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-15 -17,-19 -16,-15" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-23,-11 -25,-15 -16,-15" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-50,20 -47,22 -47,22" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-50,20 -47,22 -49,19" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="3,5 3,-2 9,2" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="9,2 14,-1 15,5" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="15,5 14,-1 20,2" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-49,19 -47,22 -47,22" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-49,19 -47,22 -46,14" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="4,12 1,14 25,-1" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="4,12 25,-1 4,12" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="9,15 6,14 25,-1" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="45,13 9,15 25,-1" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="35,6 17,7 25,-1" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="45,13 25,-1 46,13" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="46,13 25,-1 45,10" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="6,14 6,13 25,-1" />
@@ -211,16 +253,19 @@
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="25,-1 5,12 4,12" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="4,11 25,-1 0,14" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="0,14 25,-1 1,14" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="25,-1 2,-43 48,-20" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="25,-1 48,-20 45,10" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="25,-1 19,-11 30,-6" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="25,-1 36,-10 35,4" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-5,6 -10,8 -25,-1" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-1 -10,8 0,14" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-1 0,14 -39,6" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-1 -13,6 -32,3" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-1 -39,6 -39,-3" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-13,-22 -24,-21 -13,-27" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="46,46 46,43 41,49" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="39,48 46,46 41,49" />
     <polygon fill="rgba(177,177,177,1)" stroke="none" points="-44,16 -47,22 -38,12" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-46,14 -47,22 -44,16" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="19,-11 25,-16 30,-6" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="19,-11 14,-22 25,-16" />
     <polygon fill="rgba(147,147,147,1)" stroke="none" points="49,32 44,41 44,36" />
     <polygon fill="rgba(147,147,147,1)" stroke="none" points="44,36 44,41 39,45" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="46,43 44,41 51,35" />
@@ -232,6 +277,8 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="1,-43 -2,-30 0,-43" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="1,-43 0,-43 0,-29" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-1,-43 0,-29 0,-43" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="14,-22 19,-27 25,-16" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="14,-22 8,-32 19,-27" />
     <polygon fill="rgba(119,119,119,1)" stroke="none" points="2,-46 2,-43 1,-43" />
     <polygon fill="rgba(119,119,119,1)" stroke="none" points="2,-46 1,-43 1,-46" />
     <polygon fill="rgba(115,115,115,1)" stroke="none" points="0,-46 -1,-43 -1,-46" />
@@ -250,13 +297,15 @@
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="0,-29 2,-43 2,-43" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-2,-43 -4,-29 -2,-43" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-2,-43 -4,-29 0,-29" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-32 13,-37 19,-27" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="8,-32 2,-43 13,-37" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="24,-35 48,-20 2,-43" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="24,-35 2,-43 2,-45" />
     <polygon fill="rgba(126,126,126,1)" stroke="none" points="-2,-46 -2,-43 -2,-45" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-2,-45 -2,-43 -24,-35" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-24,-35 -2,-43 -48,-20" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="10,-28 7,-29 2,-43" />
-    <polygon fill="rgba(131,131,131,1)" stroke="none" points="48,-20 15,-26 2,-43" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="24,-32 8,-35 2,-43" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="2,-43 15,-26 13,-28" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="2,-43 13,-28 10,-28" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-2,-30 -5,-29 -2,-43" />
@@ -264,13 +313,15 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-2,-43 -8,-29 -11,-28" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-11,-28 -13,-27 -2,-43" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-2,-43 -13,-27 -14,-27" />
-    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-2,-43 -14,-27 -48,-20" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-2,-43 -8,-35 -24,-32" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="7,-29 4,-30 2,-43" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="2,-43 4,-30 1,-30" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-32,-2 -39,-3 -23,-7" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-39,-3 -23,-11 -23,-7" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="4,-29 7,-29 2,-43" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="2,-43 7,-29 11,-28" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="2,-43 11,-28 48,-20" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-48,-20 -16,-25 -2,-43" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="2,-43 6,-35 24,-32" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-24,-32 -9,-34 -2,-43" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-2,-43 -16,-25 -14,-27" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-2,-43 -14,-27 -11,-28" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="4,-29 2,-43 0,-29" />
@@ -298,6 +349,13 @@
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="2,-45 5,-42 24,-35" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="2,-45 2,-43 3,-43" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="2,-45 3,-43 4,-43" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-24,-27 -13,-32 -13,-27" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-24,-21 -24,-27 -13,-27" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,-15 -27,-20 -17,-19" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="3,5 9,2 9,8" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="9,8 9,2 15,5" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-33,-11 -25,-15 -23,-11" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-31,-7 -33,-11 -23,-11" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-46,14 -47,2 -40,10" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-40,10 -47,2 -41,-1" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-41,-1 -39,-3 -40,10" />
@@ -305,6 +363,8 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-39,6 -40,10 -39,-3" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="39,45 41,49 41,47" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="39,45 41,47 44,36" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-13,6 -20,10 -32,3" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-32,3 -20,10 -39,6" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-44,16 -38,12 -45,10" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-45,10 -38,12 -39,6" />
     <polygon fill="rgba(182,182,182,1)" stroke="none" points="41,47 51,35 46,38" />
@@ -312,6 +372,8 @@
     <polygon fill="rgba(38,38,38,1)" stroke="none" points="2,-44 2,-43 0,-43" />
     <polygon fill="rgba(38,38,38,1)" stroke="none" points="2,-44 0,-43 0,-44" />
     <polygon fill="rgba(37,37,37,1)" stroke="none" points="0,-44 0,-43 -1,-43" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-24,-27 -24,-32 -13,-32" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-13,-32 -24,-32 -13,-37" />
     <polygon fill="rgba(37,37,37,1)" stroke="none" points="0,-44 -1,-43 -1,-44" />
     <polygon fill="rgba(38,38,38,1)" stroke="none" points="-1,-44 -1,-43 -2,-43" />
     <polygon fill="rgba(39,39,39,1)" stroke="none" points="3,-44 3,-43 2,-43" />
@@ -333,6 +395,8 @@
     <polygon fill="rgba(43,43,43,1)" stroke="none" points="-2,-45 -2,-44 -3,-44" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="4,-43 4,-43 4,-43" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="4,-43 4,-43 4,-44" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="36,-10 47,-5 35,4" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="35,4 47,-5 45,10" />
     <polygon fill="rgba(44,44,44,1)" stroke="none" points="3,-44 4,-44 3,-44" />
     <polygon fill="rgba(44,44,44,1)" stroke="none" points="3,-44 3,-44 2,-44" />
     <polygon fill="rgba(43,43,43,1)" stroke="none" points="-4,-43 -4,-43 -5,-43" />
@@ -348,6 +412,7 @@
     <polygon fill="rgba(43,43,43,1)" stroke="none" points="-4,-43 -5,-42 -5,-43" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="2,-45 2,-44 1,-45" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="2,-45 1,-45 1,-45" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="4,11 3,5 9,8" />
     <polygon fill="rgba(47,47,47,1)" stroke="none" points="-1,-45 -2,-45 -2,-45" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="-2,-45 -2,-45 -3,-44" />
     <polygon fill="rgba(46,46,46,1)" stroke="none" points="4,-44 4,-43 4,-44" />
@@ -369,6 +434,7 @@
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="-1,-45 -1,-45 -2,-45" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="5,-43 5,-43 4,-43" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="5,-43 4,-43 4,-44" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="30,-6 25,-16 36,-10" />
     <polygon fill="rgba(50,50,50,1)" stroke="none" points="4,-44 4,-44 3,-44" />
     <polygon fill="rgba(50,50,50,1)" stroke="none" points="4,-44 3,-44 3,-45" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="2,-45 2,-45 1,-45" />
@@ -389,14 +455,20 @@
     <polygon fill="rgba(56,56,56,1)" stroke="none" points="3,-45 2,-45 2,-45" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-6,-41 -5,-42 -24,-35" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="-5,-43 -5,-42 -6,-41" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="19,-27 30,-21 25,-16" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="25,-16 30,-21 36,-10" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="-1,-45 -2,-45 -2,-45" />
     <polygon fill="rgba(57,57,57,1)" stroke="none" points="-2,-45 -2,-45 -3,-45" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-35,-16 -25,-15 -33,-11" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-35,-16 -27,-20 -25,-15" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="4,-44 5,-43 4,-44" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="4,-44 4,-44 4,-44" />
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="5,-43 6,-42 5,-43" />
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="5,-43 5,-43 5,-43" />
     <polygon fill="rgba(60,60,60,1)" stroke="none" points="3,-45 4,-44 3,-45" />
     <polygon fill="rgba(60,60,60,1)" stroke="none" points="3,-45 3,-45 3,-45" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="19,-27 24,-32 30,-21" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="19,-27 13,-37 24,-32" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="-4,-44 -4,-44 -5,-43" />
     <polygon fill="rgba(49,49,49,1)" stroke="none" points="-4,-44 -5,-43 -5,-43" />
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="-3,-45 -4,-44 -4,-44" />
@@ -416,6 +488,8 @@
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="24,-35 6,-42 6,-41" />
     <polygon fill="rgba(50,50,50,1)" stroke="none" points="6,-42 6,-41 6,-42" />
     <polygon fill="rgba(50,50,50,1)" stroke="none" points="6,-42 6,-42 6,-42" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="27,14 17,7 35,6" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="45,13 27,14 35,6" />
     <polygon fill="rgba(74,74,74,1)" stroke="none" points="2,-45 3,-45 2,-45" />
     <polygon fill="rgba(74,74,74,1)" stroke="none" points="2,-45 2,-45 2,-45" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-24,-35 -6,-41 -6,-41" />
@@ -429,8 +503,9 @@
     <polygon fill="rgba(67,67,67,1)" stroke="none" points="-3,-44 -4,-44 -5,-44" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="-4,-44 -5,-43 -5,-44" />
     <polygon fill="rgba(61,61,61,1)" stroke="none" points="-3,-45 -4,-44 -3,-44" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-39,6 0,14 -23,28" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-39,6 -23,28 -45,10" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-39,6 -29,8 -35,11" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-39,6 -31,17 -41,8" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-13,6 0,14 -20,10" />
     <polygon fill="rgba(61,61,61,1)" stroke="none" points="-5,-44 -5,-43 -5,-43" />
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="-5,-43 -6,-42 -5,-43" />
     <polygon fill="rgba(77,77,77,1)" stroke="none" points="3,-45 3,-45 3,-45" />
@@ -453,9 +528,12 @@
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="-6,-42 -6,-41 -6,-42" />
     <polygon fill="rgba(91,91,91,1)" stroke="none" points="0,-45 -1,-45 -1,-45" />
     <polygon fill="rgba(91,91,91,1)" stroke="none" points="-1,-45 -1,-45 -2,-45" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-41,-7 -33,-11 -31,-7" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-39,-3 -41,-7 -31,-7" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="24,-35 6,-41 6,-40" />
     <polygon fill="rgba(54,54,54,1)" stroke="none" points="6,-41 6,-40 6,-41" />
     <polygon fill="rgba(54,54,54,1)" stroke="none" points="6,-41 6,-41 6,-42" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="27,14 9,15 17,7" />
     <polygon fill="rgba(72,72,72,1)" stroke="none" points="4,-44 5,-43 4,-44" />
     <polygon fill="rgba(72,72,72,1)" stroke="none" points="4,-44 4,-44 4,-44" />
     <polygon fill="rgba(92,92,92,1)" stroke="none" points="2,-45 2,-45 2,-45" />
@@ -554,6 +632,7 @@
     <polygon fill="rgba(180,180,180,1)" stroke="none" points="-8,7 -5,6 -8,8" />
     <polygon fill="rgba(95,95,95,1)" stroke="none" points="3,-44 3,-44 3,-44" />
     <polygon fill="rgba(95,95,95,1)" stroke="none" points="3,-44 3,-44 2,-44" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-24,-21 -36,-21 -24,-27" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-6,-40 -6,-40 -24,-35" />
     <polygon fill="rgba(70,70,70,1)" stroke="none" points="-6,-41 -6,-40 -6,-40" />
     <polygon fill="rgba(90,90,90,1)" stroke="none" points="4,-44 4,-43 4,-44" />
@@ -597,6 +676,8 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="52,33 49,32 49,32" />
     <polygon fill="rgba(97,97,97,1)" stroke="none" points="-3,-44 -3,-44 -4,-44" />
     <polygon fill="rgba(91,91,91,1)" stroke="none" points="-3,-44 -4,-43 -4,-44" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-31,17 -34,19 -41,8" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-41,8 -34,19 -45,10" />
     <polygon fill="rgba(132,132,132,1)" stroke="none" points="49,32 44,36 44,35" />
     <polygon fill="rgba(124,124,124,1)" stroke="none" points="49,32 44,35 49,32" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="52,33 49,32 52,32" />
@@ -641,6 +722,8 @@
     <polygon fill="rgba(90,90,90,1)" stroke="none" points="-5,-42 -6,-42 -6,-41" />
     <polygon fill="rgba(81,81,81,1)" stroke="none" points="-6,-42 -6,-40 -6,-41" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-10,7 -8,7 -10,7" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-29,8 -25,13 -35,11" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-29,8 -20,10 -25,13" />
     <polygon fill="rgba(99,99,99,1)" stroke="none" points="3,-43 4,-43 4,-44" />
     <polygon fill="rgba(99,99,99,1)" stroke="none" points="3,-43 4,-44 3,-44" />
     <polygon fill="rgba(95,95,95,1)" stroke="none" points="4,-43 5,-42 5,-43" />
@@ -650,6 +733,8 @@
     <polygon fill="rgba(89,89,89,1)" stroke="none" points="5,-41 6,-40 6,-41" />
     <polygon fill="rgba(89,89,89,1)" stroke="none" points="5,-41 6,-41 6,-41" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,-43 3,-44 0,-43" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="6,-35 29,-24 24,-32" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="6,-35 11,-28 29,-24" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-3,8 -3,8 -2,8" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-3,8 -2,8 -2,8" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-2,8 -2,8 -2,8" />
@@ -740,6 +825,8 @@
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-1,8 -2,8 -1,8" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="1,10 0,8 0,9" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-1,8 0,9 0,8" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-8,-35 -31,-24 -24,-32" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-8,-35 -14,-27 -31,-24" />
     <polygon fill="rgba(102,102,102,1)" stroke="none" points="3,-43 4,-43 3,-43" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-1,8 -1,9 -1,9" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-1,8 -1,9 -1,8" />
@@ -761,10 +848,13 @@
     <polygon fill="rgba(102,102,102,1)" stroke="none" points="-3,-43 -3,-43 -3,-43" />
     <polygon fill="rgba(189,189,189,1)" stroke="none" points="52,33 47,38 52,34" />
     <polygon fill="rgba(184,184,184,1)" stroke="none" points="52,34 47,38 46,38" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-35,-16 -37,-20 -27,-20" />
     <polygon fill="rgba(105,105,105,1)" stroke="none" points="-4,-43 -4,-42 -4,-42" />
     <polygon fill="rgba(104,104,104,1)" stroke="none" points="-4,-42 -5,-41 -4,-42" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-1,8 -1,8 -1,8" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-1,8 -1,8 0,8" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="31,-23 8,-35 24,-32" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="31,-23 15,-26 8,-35" />
     <polygon fill="rgba(105,105,105,1)" stroke="none" points="-4,-43 -4,-42 -3,-43" />
     <polygon fill="rgba(103,103,103,1)" stroke="none" points="-5,-41 -5,-40 -5,-39" />
     <polygon fill="rgba(93,93,93,1)" stroke="none" points="-5,-40 -5,-39 -5,-39" />
@@ -789,7 +879,7 @@
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-5,9 -5,9 -5,8" />
     <polygon fill="rgba(106,106,106,1)" stroke="none" points="4,-41 5,-40 5,-41" />
     <polygon fill="rgba(106,106,106,1)" stroke="none" points="4,-41 5,-41 5,-42" />
-    <polygon fill="rgba(190,190,190,1)" stroke="none" points="14,-30 24,-35 5,-39" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="10,-34 15,-37 5,-39" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="14,-30 5,-39 4,-38" />
     <polygon fill="rgba(101,101,101,1)" stroke="none" points="4,-39 4,-38 5,-39" />
     <polygon fill="rgba(101,101,101,1)" stroke="none" points="4,-39 5,-39 5,-40" />
@@ -867,13 +957,15 @@
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-5,10 -5,10 -7,10" />
     <polygon fill="rgba(253,253,253,1)" stroke="none" points="-5,9 -5,10 -5,10" />
     <polygon fill="rgba(253,253,253,1)" stroke="none" points="-5,9 -5,10 -5,9" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-36,-21 -36,-26 -24,-27" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-24,-27 -36,-26 -24,-32" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-7,10 -5,10 -5,11" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-7,10 -5,11 -5,11" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="0,14 -7,10 -4,11" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-4,11 -7,10 -5,11" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-3,-38 -4,-38 -13,-30" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-13,-30 -4,-38 -14,-30" />
-    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-14,-30 -4,-38 -24,-35" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-9,-34 -4,-38 -14,-37" />
     <polygon fill="rgba(111,111,111,1)" stroke="none" points="-4,-39 -4,-38 -3,-38" />
     <polygon fill="rgba(112,112,112,1)" stroke="none" points="3,-42 3,-41 4,-42" />
     <polygon fill="rgba(116,116,116,1)" stroke="none" points="3,-41 4,-41 4,-42" />
@@ -881,6 +973,8 @@
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-5,9 -5,9 -4,9" />
     <polygon fill="rgba(117,117,117,1)" stroke="none" points="-4,-41 -5,-40 -4,-40" />
     <polygon fill="rgba(112,112,112,1)" stroke="none" points="-5,-40 -4,-39 -4,-40" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-32,-23 -9,-34 -24,-32" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-32,-23 -16,-25 -9,-34" />
     <polygon fill="rgba(107,107,107,1)" stroke="none" points="1,-42 2,-42 2,-42" />
     <polygon fill="rgba(106,106,106,1)" stroke="none" points="2,-42 2,-42 3,-42" />
     <polygon fill="rgba(235,235,235,1)" stroke="none" points="-5,9 -5,10 -5,9" />
@@ -897,6 +991,8 @@
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-45,10 -46,13 -46,13" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-45,10 -46,13 -47,12" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-45,0 -45,10 -48,-20" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-43,-11 -35,-16 -33,-11" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-41,-7 -43,-11 -33,-11" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="-46,11 -48,-20 -45,10" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="45,10 48,-20 48,-20" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="45,10 48,-20 46,11" />
@@ -908,6 +1004,8 @@
     <polygon fill="rgba(181,181,181,1)" stroke="none" points="-46,0 -40,-3 -46,0" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-3,11 1,9 -3,12" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-3,11 1,9 -3,11" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-20,10 -16,15 -25,13" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-20,10 -10,12 -16,15" />
     <polygon fill="rgba(116,116,116,1)" stroke="none" points="2,-42 3,-41 3,-42" />
     <polygon fill="rgba(118,118,118,1)" stroke="none" points="3,-40 3,-39 4,-39" />
     <polygon fill="rgba(118,118,118,1)" stroke="none" points="3,-40 4,-39 4,-40" />
@@ -1077,6 +1175,7 @@
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="0,14 4,11 4,11" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="44,35 47,36 46,35" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="44,35 46,35 39,23" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-35,11 -25,13 -31,17" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-3,11 -4,10 -3,12" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="46,13 47,12 47,12" />
     <polygon fill="rgba(62,62,62,1)" stroke="none" points="-47,12 -49,-19 -47,12" />
@@ -1092,6 +1191,8 @@
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-1,12 -1,13 -2,12" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-1,11 1,12 -1,12" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-1,12 1,12 1,12" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="19,-32 15,-37 10,-34" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="19,-32 24,-35 15,-37" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-3,11 -3,11 -4,10" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-4,10 -3,11 -4,11" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="1,11 0,10 1,12" />
@@ -1101,6 +1202,10 @@
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="0,13 4,11 0,14" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="0,13 1,12 4,11" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="1,11 4,11 1,12" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="36,-10 30,-21 42,-15" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="36,-10 48,-20 47,-5" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-9,-34 -14,-37 -19,-32" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-19,-32 -14,-37 -24,-35" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="4,11 4,12 5,12" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="4,11 4,11 4,12" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="4,12 4,11 4,12" />
@@ -1113,8 +1218,12 @@
     <polygon fill="rgba(78,78,78,1)" stroke="none" points="-46,13 -49,-19 -47,12" />
     <polygon fill="rgba(62,62,62,1)" stroke="none" points="-47,12 -49,-19 -49,-19" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-3,12 -3,13 0,14" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-10,12 -6,18 -16,15" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-10,12 0,14 -6,18" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="4,11 5,12 5,11" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="5,11 5,12 5,12" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="30,-21 36,-26 42,-15" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="30,-21 24,-32 36,-26" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-2,11 -3,12 -2,12" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-2,12 -3,12 -3,13" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="-1,13 -2,11 -2,12" />
@@ -1131,6 +1240,10 @@
     <polygon fill="rgba(189,189,189,1)" stroke="none" points="5,12 4,12 4,12" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="4,11 4,11 4,12" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="4,12 4,11 5,11" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="48,-20 31,-23 24,-32" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-24,-32 -31,-24 -48,-20" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="24,-32 29,-24 48,-20" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-48,-20 -32,-23 -24,-32" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-3,13 0,14 0,14" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-3,12 0,13 -3,13" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-3,13 0,13 0,14" />
@@ -1157,8 +1270,8 @@
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="45,13 46,13 46,4" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="46,4 46,13 48,-18" />
     <polygon fill="rgba(93,93,93,1)" stroke="none" points="-46,13 -48,-18 -49,-18" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-48,-18 -46,13 -3,10" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-3,10 -46,13 -23,28" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-46,6 -46,13 -36,12" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-36,12 -46,13 -40,17" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="6,12 6,13 6,12" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="6,12 6,13 6,13" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="5,12 6,12 5,12" />
@@ -1168,6 +1281,8 @@
     <polygon fill="rgba(239,239,239,1)" stroke="none" points="6,13 5,13 5,12" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="6,12 6,13 6,13" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="6,13 6,13 6,14" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-16,15 -21,19 -25,13" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-25,13 -21,19 -31,17" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="39,23 46,35 42,24" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="6,18 10,15 45,13" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="10,15 9,15 45,13" />
@@ -1180,6 +1295,8 @@
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="5,12 6,12 6,13" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="6,13 6,12 6,13" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="39,23 42,24 40,17" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-46,-16 -37,-20 -35,-16" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-43,-11 -46,-16 -35,-16" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="6,14 5,14 1,14" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="5,13 5,14 6,14" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="5,13 6,14 6,13" />
@@ -1202,7 +1319,7 @@
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="24,-35 40,-25 41,-25" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="24,-35 41,-25 48,-23" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="15,-29 24,-35 14,-30" />
-    <polygon fill="rgba(190,190,190,1)" stroke="none" points="15,-29 32,-25 24,-35" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="20,-32 28,-30 24,-35" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="24,-35 32,-25 33,-25" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="24,-35 33,-25 34,-25" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-48,-23 -41,-25 -24,-35" />
@@ -1213,7 +1330,7 @@
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-24,-35 -36,-25 -35,-25" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-35,-25 -34,-25 -24,-35" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-24,-35 -34,-25 -33,-25" />
-    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-24,-35 -33,-25 -14,-30" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-24,-35 -29,-30 -19,-32" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="5,15 4,15 1,14" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="1,14 4,15 4,15" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="4,15 3,15 1,14" />
@@ -1250,6 +1367,7 @@
     <polygon fill="rgba(202,202,202,1)" stroke="none" points="6,14 6,15 5,15" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="4,14 4,15 5,15" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="4,14 5,15 5,14" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="14,-30 19,-32 10,-34" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="5,14 6,13 6,14" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,15 2,15 3,15" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="3,15 2,15 3,15" />
@@ -1275,12 +1393,13 @@
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="6,17 5,15 5,15" />
     <polygon fill="rgba(191,191,191,1)" stroke="none" points="5,15 5,14 5,15" />
     <polygon fill="rgba(202,202,202,1)" stroke="none" points="6,14 5,15 5,14" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-14,-30 -9,-34 -19,-32" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="3,14 3,15 4,15" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="3,14 4,15 4,14" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,15 23,28 1,15" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="23,28 10,37 1,15" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="12,21 5,26 1,15" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="1,15 10,37 4,41" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="1,15 4,41 -23,28" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="1,15 2,28 -11,21" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="1,15 1,14 2,15" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="2,14 3,15 3,14" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="3,14 3,15 3,15" />
@@ -1330,6 +1449,8 @@
     <polygon fill="rgba(182,182,182,1)" stroke="none" points="4,15 4,15 5,14" />
     <polygon fill="rgba(197,197,197,1)" stroke="none" points="-5,-29 -2,-33 -5,-32" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="-5,-29 -5,-32 -8,-29" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-16,15 -11,21 -21,19" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-16,15 -6,18 -11,21" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="3,15 3,16 4,16" />
     <polygon fill="rgba(174,174,174,1)" stroke="none" points="3,15 3,15 3,15" />
     <polygon fill="rgba(174,174,174,1)" stroke="none" points="3,15 3,15 3,16" />
@@ -1370,15 +1491,29 @@
     <polygon fill="rgba(37,37,37,1)" stroke="none" points="-7,-29 -9,-55 -8,-55" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="4,15 6,17 4,16" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="4,16 6,17 6,18" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-36,-21 -48,-20 -36,-26" />
     <polygon fill="rgba(255,255,255,1)" stroke="none" points="6,16 4,15 6,17" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="6,16 6,17 4,15" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="4,15 6,17 4,15" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-36,12 -40,17 -30,16" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-30,16 -40,17 -35,20" />
     <polygon fill="rgba(193,193,193,1)" stroke="none" points="13,-28 13,-31 10,-28" />
     <polygon fill="rgba(193,193,193,1)" stroke="none" points="10,-28 13,-31 10,-31" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-31,17 -21,19 -27,22" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-31,17 -23,28 -34,19" />
     <polygon fill="rgba(195,195,195,1)" stroke="none" points="-11,-28 -8,-32 -11,-31" />
     <polygon fill="rgba(192,192,192,1)" stroke="none" points="-11,-28 -11,-31 -13,-27" />
-    <polygon fill="rgba(41,41,41,1)" stroke="none" points="6,18 40,17 23,28" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="41,8 23,28 40,17" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="23,17 40,17 32,22" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="40,12 32,22 40,17" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-46,6 -36,12 -37,5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-47,-2 -46,6 -37,5" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-29,-30 -24,-27 -19,-32" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-19,-32 -24,-27 -14,-30" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="24,-27 28,-30 20,-32" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="15,-29 24,-27 20,-32" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="23,17 32,22 14,23" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="6,18 23,17 14,23" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-46,-16 -48,-20 -37,-20" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="48,-20 11,-28 14,-27" />
     <polygon fill="rgba(40,40,40,1)" stroke="none" points="13,-54 14,-27 11,-28" />
     <polygon fill="rgba(39,39,39,1)" stroke="none" points="13,-54 11,-28 11,-55" />
@@ -1407,6 +1542,9 @@
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="47,5 42,9 47,5" />
     <polygon fill="rgba(196,196,196,1)" stroke="none" points="48,7 43,11 48,8" />
     <polygon fill="rgba(192,192,192,1)" stroke="none" points="48,8 43,11 43,12" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-21,19 -17,24 -27,22" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-21,19 -11,21 -17,24" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="42,-15 36,-26 48,-20" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="48,-20 14,-27 16,-25" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="15,-53 16,-25 14,-27" />
     <polygon fill="rgba(40,40,40,1)" stroke="none" points="15,-53 14,-27 14,-53" />
@@ -1432,8 +1570,14 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-48,-20 -15,-26 -17,-25" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-15,-26 -14,-30 -16,-29" />
     <polygon fill="rgba(186,186,186,1)" stroke="none" points="-15,-26 -16,-29 -17,-25" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="32,18 32,22 40,12" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="41,8 32,18 40,12" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-29,-30 -33,-25 -24,-27" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="24,-27 32,-25 28,-30" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-14,-30 -33,-25 -32,-24" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-14,-30 -32,-24 -16,-29" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-30,16 -35,20 -25,20" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-25,20 -35,20 -29,24" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="7,75 4,73 12,70" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="12,68 7,75 12,70" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="19,-24 17,-25 48,-20" />
@@ -1459,8 +1603,14 @@
     <polygon fill="rgba(186,186,186,1)" stroke="none" points="-17,-25 -16,-29 -17,-28" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-48,-20 -17,-25 -19,-23" />
     <polygon fill="rgba(183,183,183,1)" stroke="none" points="-17,-25 -17,-28 -19,-23" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="48,-18 10,28 41,8" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="41,8 10,28 23,28" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-47,-2 -37,5 -37,-3" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-48,-10 -47,-2 -37,-3" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,28 -10,35 -11,21" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-11,21 -10,35 -23,28" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="16,33 5,26 12,21" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="23,28 16,33 12,21" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="42,1 33,12 41,8" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="41,8 26,17 32,18" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="42,10 43,12 43,10" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="43,10 43,12 43,11" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="42,10 42,9 43,12" />
@@ -1472,6 +1622,9 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="48,-20 20,-22 19,-24" />
     <polygon fill="rgba(180,180,180,1)" stroke="none" points="20,-22 20,-25 19,-24" />
     <polygon fill="rgba(180,180,180,1)" stroke="none" points="19,-24 20,-25 19,-27" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="-27,22 -17,24 -23,28" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="14,23 32,22 23,28" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="32,18 23,28 32,22" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-31,-24 -19,-26 -17,-28" />
     <polygon fill="rgba(183,183,183,1)" stroke="none" points="-19,-23 -17,-28 -19,-26" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="4,73 7,75 4,70" />
@@ -1489,15 +1642,25 @@
     <polygon fill="rgba(47,47,47,1)" stroke="none" points="-18,-23 -20,-49 -19,-50" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="31,-24 19,-27 31,-23" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="31,-23 19,-27 20,-25" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="35,6 33,12 42,1" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="44,-5 35,6 42,1" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-37,5 -36,12 -26,11" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-26,11 -36,12 -30,16" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="21,-20 20,-22 48,-20" />
     <polygon fill="rgba(176,176,176,1)" stroke="none" points="21,-20 21,-24 20,-22" />
     <polygon fill="rgba(176,176,176,1)" stroke="none" points="20,-22 21,-24 20,-25" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="4,70 7,75 7,72" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-25,20 -29,24 -18,24" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-18,24 -29,24 -23,28" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-31,-24 -20,-25 -19,-26" />
     <polygon fill="rgba(179,179,179,1)" stroke="none" points="-20,-22 -19,-26 -20,-25" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="4,70 7,72 9,61" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-48,-20 -20,-22 -21,-20" />
     <polygon fill="rgba(175,175,175,1)" stroke="none" points="-20,-22 -20,-25 -21,-20" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="26,17 17,28 32,18" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="32,18 17,28 23,28" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-48,-10 -37,-3 -38,-11" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-48,-18 -48,-10 -38,-11" />
     <polygon fill="rgba(38,38,38,1)" stroke="none" points="-35,-26 -35,-25 -36,-25" />
     <polygon fill="rgba(38,38,38,1)" stroke="none" points="-35,-26 -36,-25 -36,-26" />
     <polygon fill="rgba(37,37,37,1)" stroke="none" points="-36,-26 -36,-25 -38,-25" />
@@ -1526,12 +1689,15 @@
     <polygon fill="rgba(39,39,39,1)" stroke="none" points="35,-26 35,-25 34,-25" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="31,-23 20,-25 31,-22" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="31,-22 20,-25 21,-24" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="37,0 35,6 44,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="46,-11 37,0 44,-5" />
     <polygon fill="rgba(40,40,40,1)" stroke="none" points="41,-26 41,-25 40,-25" />
     <polygon fill="rgba(40,40,40,1)" stroke="none" points="41,-26 40,-25 40,-26" />
     <polygon fill="rgba(40,40,40,1)" stroke="none" points="-33,-26 -33,-25 -34,-25" />
     <polygon fill="rgba(40,40,40,1)" stroke="none" points="-33,-26 -34,-25 -34,-26" />
     <polygon fill="rgba(182,182,182,1)" stroke="none" points="11,64 7,72 17,59" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="9,61 7,72 11,64" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="16,33 10,37 5,26" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="39,-27 39,-26 37,-26" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="39,-27 37,-26 37,-27" />
     <polygon fill="rgba(42,42,42,1)" stroke="none" points="37,-27 37,-26 36,-26" />
@@ -1639,6 +1805,7 @@
     <polygon fill="rgba(49,49,49,1)" stroke="none" points="34,-27 34,-26 33,-26" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="-39,-27 -40,-26 -40,-27" />
     <polygon fill="rgba(49,49,49,1)" stroke="none" points="-40,-27 -40,-26 -41,-26" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="35,6 26,17 33,12" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="-36,-27 -36,-27 -37,-27" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="-36,-27 -37,-27 -37,-27" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="-37,-27 -37,-27 -38,-27" />
@@ -1699,6 +1866,9 @@
     <polygon fill="rgba(57,57,57,1)" stroke="none" points="35,-27 34,-27 34,-26" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="-39,-27 -40,-27 -39,-27" />
     <polygon fill="rgba(57,57,57,1)" stroke="none" points="-39,-27 -40,-27 -41,-26" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="39,-7 37,0 46,-11" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="48,-18 39,-7 46,-11" />
+    <polygon fill="rgba(41,41,41,1)" stroke="none" points="2,28 4,41 -10,35" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="42,-26 42,-25 42,-26" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="42,-26 42,-26 41,-26" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="-33,-26 -32,-25 -33,-26" />
@@ -1713,6 +1883,8 @@
     <polygon fill="rgba(60,60,60,1)" stroke="none" points="41,-26 40,-27 40,-27" />
     <polygon fill="rgba(60,60,60,1)" stroke="none" points="-34,-26 -33,-26 -34,-27" />
     <polygon fill="rgba(60,60,60,1)" stroke="none" points="-34,-26 -34,-27 -34,-27" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-30,16 -25,20 -20,15" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-26,11 -30,16 -20,15" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="33,-26 32,-26 32,-25" />
     <polygon fill="rgba(49,49,49,1)" stroke="none" points="32,-26 31,-24 32,-25" />
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="34,-26 32,-26 33,-26" />
@@ -1779,13 +1951,15 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="21,-19 49,-19 49,-18" />
     <polygon fill="rgba(165,165,165,1)" stroke="none" points="21,-17 21,-20 21,-19" />
     <polygon fill="rgba(165,165,165,1)" stroke="none" points="21,-19 21,-20 21,-22" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-37,5 -26,4 -37,-3" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-37,5 -26,11 -26,4" />
     <polygon fill="rgba(74,74,74,1)" stroke="none" points="40,-27 40,-27 39,-27" />
     <polygon fill="rgba(74,74,74,1)" stroke="none" points="40,-27 39,-27 39,-27" />
     <polygon fill="rgba(74,74,74,1)" stroke="none" points="-35,-27 -34,-27 -35,-27" />
     <polygon fill="rgba(74,74,74,1)" stroke="none" points="-35,-27 -35,-27 -36,-27" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-23,28 4,41 3,42" />
     <polygon fill="rgba(41,41,41,1)" stroke="none" points="-23,28 3,42 -3,42" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-3,10 -23,28 -3,42" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-13,19 -23,28 -13,35" />
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="-43,-24 -43,-23 -44,-22" />
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="31,-24 31,-23 31,-22" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-31,-23 -21,-21 -21,-23" />
@@ -1896,6 +2070,8 @@
     <polygon fill="rgba(78,78,78,1)" stroke="none" points="35,-27 34,-26 34,-26" />
     <polygon fill="rgba(78,78,78,1)" stroke="none" points="-40,-27 -41,-26 -40,-26" />
     <polygon fill="rgba(82,82,82,1)" stroke="none" points="-40,-26 -41,-26 -42,-26" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="28,11 35,6 37,0" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="28,11 26,17 35,6" />
     <polygon fill="rgba(58,58,58,1)" stroke="none" points="31,-23 31,-22 31,-22" />
     <polygon fill="rgba(58,58,58,1)" stroke="none" points="-44,-23 -44,-22 -44,-22" />
     <polygon fill="rgba(181,181,181,1)" stroke="none" points="-49,-22 -49,-18 -49,-21" />
@@ -1984,19 +2160,19 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="17,-12 19,-14 48,-18" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="19,-14 20,-15 48,-18" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="48,-18 20,-15 21,-17" />
-    <polygon fill="rgba(131,131,131,1)" stroke="none" points="3,10 13,-10 48,-18" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="27,-5 31,-14 48,-18" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="48,-18 13,-10 15,-11" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="48,-18 15,-11 17,-12" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-48,-18 -21,-17 -20,-15" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-20,-15 -19,-13 -48,-18" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-48,-18 -19,-13 -17,-12" />
-    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-48,-18 -17,-12 -3,10" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,10 4,32 48,-18" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-48,-18 -33,-15 -27,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="38,-11 38,-6 48,-18" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="48,-18 4,32 10,28" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="20,-17 19,-15 48,-18" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="48,-18 19,-15 17,-13" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="48,-18 17,-13 3,10" />
-    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-3,10 -12,-10 -48,-18" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="48,-18 33,-15 27,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-27,-5 -30,-14 -48,-18" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-48,-18 -12,-10 -15,-11" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-48,-18 -15,-11 -17,-13" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-17,-13 -19,-15 -48,-18" />
@@ -2199,6 +2375,8 @@
     <polygon fill="rgba(71,71,71,1)" stroke="none" points="-3,-57 0,-57 0,-57" />
     <polygon fill="rgba(71,71,71,1)" stroke="none" points="2,-57 0,-57 2,-57" />
     <polygon fill="rgba(71,71,71,1)" stroke="none" points="2,-57 0,-57 0,-57" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="29,5 28,11 37,0" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="39,-7 29,5 37,0" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="8,-57 10,-56 8,-56" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="8,-56 10,-56 10,-56" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="-8,-56 -6,-57 -6,-57" />
@@ -2384,6 +2562,8 @@
     <polygon fill="rgba(73,73,73,1)" stroke="none" points="-8,-57 -5,-57 -8,-57" />
     <polygon fill="rgba(91,91,91,1)" stroke="none" points="-3,-57 -5,-57 -5,-57" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="0,-49 5,-57 2,-57" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-20,15 -25,20 -13,19" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-13,19 -25,20 -18,24" />
     <polygon fill="rgba(106,106,106,1)" stroke="none" points="42,-23 43,-22 43,-22" />
     <polygon fill="rgba(106,106,106,1)" stroke="none" points="42,-23 43,-22 43,-23" />
     <polygon fill="rgba(106,106,106,1)" stroke="none" points="-33,-23 -33,-22 -32,-22" />
@@ -2443,6 +2623,8 @@
     <polygon fill="rgba(109,109,109,1)" stroke="none" points="-43,-23 -43,-22 -42,-22" />
     <polygon fill="rgba(105,105,105,1)" stroke="none" points="40,-24 41,-24 40,-24" />
     <polygon fill="rgba(105,105,105,1)" stroke="none" points="-36,-24 -34,-24 -35,-24" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="28,11 18,22 26,17" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="26,17 10,28 17,28" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="-5,-57 -8,-56 0,-49" />
     <polygon fill="rgba(91,91,91,1)" stroke="none" points="-8,-56 -5,-57 -8,-57" />
     <polygon fill="rgba(92,92,92,1)" stroke="none" points="7,-57 9,-56 7,-57" />
@@ -2463,6 +2645,8 @@
     <polygon fill="rgba(46,46,46,1)" stroke="none" points="15,-54 13,-55 15,-54" />
     <polygon fill="rgba(46,46,46,1)" stroke="none" points="15,-54 13,-55 13,-55" />
     <polygon fill="rgba(154,154,154,1)" stroke="none" points="-20,-15 -21,-20 -20,-18" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="33,-15 10,-2 27,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="33,-15 17,-13 10,-2" />
     <polygon fill="rgba(50,50,50,1)" stroke="none" points="-11,-56 -13,-55 -13,-55" />
     <polygon fill="rgba(58,58,58,1)" stroke="none" points="-11,-56 -13,-55 -10,-56" />
     <polygon fill="rgba(92,92,92,1)" stroke="none" points="-10,-56 -8,-56 -8,-57" />
@@ -2475,7 +2659,9 @@
     <polygon fill="rgba(112,112,112,1)" stroke="none" points="41,-24 42,-23 41,-24" />
     <polygon fill="rgba(105,105,105,1)" stroke="none" points="-36,-24 -35,-24 -34,-24" />
     <polygon fill="rgba(112,112,112,1)" stroke="none" points="-35,-24 -34,-23 -34,-24" />
-    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-15,-14 -33,-20 -27,-8" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-37,-3 -26,4 -27,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-38,-11 -37,-3 -27,-5" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-24,-17 -33,-20 -30,-14" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-27,-8 -33,-20 -34,-19" />
     <polygon fill="rgba(106,106,106,1)" stroke="none" points="39,-24 41,-24 40,-24" />
     <polygon fill="rgba(110,110,110,1)" stroke="none" points="41,-20 41,-19 42,-20" />
@@ -2541,6 +2727,8 @@
     <polygon fill="rgba(116,116,116,1)" stroke="none" points="-36,-23 -34,-23 -35,-24" />
     <polygon fill="rgba(118,118,118,1)" stroke="none" points="-34,-21 -34,-20 -33,-20" />
     <polygon fill="rgba(118,118,118,1)" stroke="none" points="-34,-21 -33,-20 -33,-21" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-33,-15 -10,-1 -27,-5" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-33,-15 -17,-12 -10,-1" />
     <polygon fill="rgba(75,75,75,1)" stroke="none" points="-20,-42 -20,-43 -19,-15" />
     <polygon fill="rgba(85,85,85,1)" stroke="none" points="19,-15 20,-43 17,-13" />
     <polygon fill="rgba(73,73,73,1)" stroke="none" points="19,-15 21,-44 20,-43" />
@@ -2598,7 +2786,7 @@
     <polygon fill="rgba(61,61,61,1)" stroke="none" points="14,-54 12,-55 14,-55" />
     <polygon fill="rgba(61,61,61,1)" stroke="none" points="14,-55 12,-55 12,-55" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="27,-8 35,-19 34,-19" />
-    <polygon fill="rgba(190,190,190,1)" stroke="none" points="27,-8 34,-19 15,-14" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="31,-13 34,-19 25,-16" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-27,-8 -40,-19 -41,-19" />
     <polygon fill="rgba(118,118,118,1)" stroke="none" points="34,-20 34,-19 35,-19" />
     <polygon fill="rgba(118,118,118,1)" stroke="none" points="-41,-20 -41,-19 -40,-19" />
@@ -2704,6 +2892,8 @@
     <polygon fill="rgba(124,124,124,1)" stroke="none" points="-39,-19 -39,-19 -38,-18" />
     <polygon fill="rgba(128,128,128,1)" stroke="none" points="35,-22 36,-20 36,-21" />
     <polygon fill="rgba(128,128,128,1)" stroke="none" points="-41,-22 -40,-20 -40,-21" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="27,1 38,-6 38,-11" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="27,1 27,6 38,-6" />
     <polygon fill="rgba(124,124,124,1)" stroke="none" points="37,-19 38,-18 38,-19" />
     <polygon fill="rgba(124,124,124,1)" stroke="none" points="-39,-19 -38,-18 -38,-19" />
     <polygon fill="rgba(129,129,129,1)" stroke="none" points="39,-20 39,-19 40,-20" />
@@ -2756,6 +2946,12 @@
     <polygon fill="rgba(141,141,141,1)" stroke="none" points="19,-14 17,-15 19,-17" />
     <polygon fill="rgba(132,132,132,1)" stroke="none" points="-39,-20 -38,-19 -38,-20" />
     <polygon fill="rgba(132,132,132,1)" stroke="none" points="37,-20 38,-19 38,-20" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="8,0 31,-14 27,-5" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="8,0 13,-10 31,-14" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-7,0 -30,-14 -27,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-7,0 -12,-10 -30,-14" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="20,16 18,22 28,11" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="29,5 20,16 28,11" />
     <polygon fill="rgba(133,133,133,1)" stroke="none" points="38,-21 39,-20 39,-21" />
     <polygon fill="rgba(133,133,133,1)" stroke="none" points="-38,-21 -37,-20 -37,-21" />
     <polygon fill="rgba(133,133,133,1)" stroke="none" points="-38,-21 -38,-20 -37,-20" />
@@ -2787,6 +2983,8 @@
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="9,61 11,62 9,60" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="9,60 11,62 11,61" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="9,60 11,61 9,60" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-13,19 -13,35 -3,26" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-3,26 -13,35 -3,42" />
     <polygon fill="rgba(44,44,44,1)" stroke="none" points="-17,-52 -17,-52 -17,-52" />
     <polygon fill="rgba(46,46,46,1)" stroke="none" points="17,-53 18,-51 17,-52" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="9,60 11,61 11,60" />
@@ -2815,6 +3013,8 @@
     <polygon fill="rgba(81,81,81,1)" stroke="none" points="-14,-54 -16,-53 -16,-53" />
     <polygon fill="rgba(94,94,94,1)" stroke="none" points="-14,-54 -16,-53 -14,-54" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="15,-54 13,-55 0,-49" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-26,4 -26,11 -15,11" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-15,11 -26,11 -20,15" />
     <polygon fill="rgba(197,197,197,1)" stroke="none" points="6,49 11,60 12,44" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="12,32 6,49 12,44" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="12,44 10,37 12,32" />
@@ -2824,12 +3024,16 @@
     <polygon fill="rgba(69,69,69,1)" stroke="none" points="16,-53 17,-53 18,-52" />
     <polygon fill="rgba(56,56,56,1)" stroke="none" points="-18,-52 -17,-53 -17,-53" />
     <polygon fill="rgba(50,50,50,1)" stroke="none" points="-18,-52 -17,-53 -19,-51" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-24,-17 -30,-14 -21,-11" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-15,-14 -24,-17 -21,-11" />
     <polygon fill="rgba(134,134,134,1)" stroke="none" points="15,-11 15,-14 17,-12" />
     <polygon fill="rgba(134,134,134,1)" stroke="none" points="17,-12 15,-14 17,-15" />
     <polygon fill="rgba(83,83,83,1)" stroke="none" points="15,-54 17,-53 16,-54" />
     <polygon fill="rgba(83,83,83,1)" stroke="none" points="16,-54 17,-53 17,-53" />
     <polygon fill="rgba(71,71,71,1)" stroke="none" points="-18,-52 -16,-53 -17,-53" />
     <polygon fill="rgba(56,56,56,1)" stroke="none" points="-18,-52 -17,-53 -18,-52" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="31,-13 25,-16 21,-11" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="21,-11 25,-16 15,-14" />
     <polygon fill="rgba(139,139,139,1)" stroke="none" points="-19,-16 -17,-15 -17,-12" />
     <polygon fill="rgba(48,48,48,1)" stroke="none" points="19,-50 18,-51 18,-51" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-3,10 -17,-12 -15,-10" />
@@ -2848,6 +3052,7 @@
     <polygon fill="rgba(84,84,84,1)" stroke="none" points="-17,-52 -16,-53 -18,-52" />
     <polygon fill="rgba(61,61,61,1)" stroke="none" points="19,-51 18,-52 19,-51" />
     <polygon fill="rgba(61,61,61,1)" stroke="none" points="19,-51 18,-52 18,-52" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="27,-5 27,1 38,-11" />
     <polygon fill="rgba(49,49,49,1)" stroke="none" points="-19,-51 -19,-50 -20,-50" />
     <polygon fill="rgba(52,52,52,1)" stroke="none" points="-19,-51 -20,-50 -18,-52" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="0,-49 -15,-53 -17,-52" />
@@ -2870,6 +3075,7 @@
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="6,49 4,41 3,48" />
     <polygon fill="rgba(128,128,128,1)" stroke="none" points="13,-10 13,-13 15,-11" />
     <polygon fill="rgba(128,128,128,1)" stroke="none" points="15,-11 13,-13 15,-14" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="20,16 10,28 18,22" />
     <polygon fill="rgba(86,86,86,1)" stroke="none" points="18,-51 17,-53 18,-52" />
     <polygon fill="rgba(86,86,86,1)" stroke="none" points="18,-52 17,-53 17,-53" />
     <polygon fill="rgba(63,63,63,1)" stroke="none" points="-18,-52 -20,-50 -19,-51" />
@@ -2882,6 +3088,8 @@
     <polygon fill="rgba(50,50,50,1)" stroke="none" points="20,-48 20,-50 19,-50" />
     <polygon fill="rgba(76,76,76,1)" stroke="none" points="-18,-52 -19,-51 -19,-51" />
     <polygon fill="rgba(87,87,87,1)" stroke="none" points="-18,-52 -19,-51 -17,-52" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="15,13 27,6 27,1" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="15,13 15,19 27,6" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="0,-49 17,-51 16,-53" />
     <polygon fill="rgba(87,87,87,1)" stroke="none" points="-17,-52 -19,-51 -18,-51" />
     <polygon fill="rgba(96,96,96,1)" stroke="none" points="-17,-52 -18,-51 -17,-52" />
@@ -2916,26 +3124,30 @@
     <polygon fill="rgba(90,90,90,1)" stroke="none" points="19,-50 18,-51 18,-52" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="13,-13 4,-4 15,-14" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="15,-14 4,-4 5,-3" />
-    <polygon fill="rgba(190,190,190,1)" stroke="none" points="15,-14 5,-3 27,-8" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="15,-14 10,-9 21,-11" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="-12,-9 -9,-8 -3,10" />
     <polygon fill="rgba(126,126,126,1)" stroke="none" points="-12,-9 -15,-14 -12,-12" />
     <polygon fill="rgba(122,122,122,1)" stroke="none" points="-12,-9 -12,-12 -9,-8" />
     <polygon fill="rgba(81,81,81,1)" stroke="none" points="-20,-50 -19,-51 -19,-51" />
     <polygon fill="rgba(70,70,70,1)" stroke="none" points="-20,-50 -19,-51 -20,-49" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-21,-11 -30,-14 -27,-8" />
     <polygon fill="rgba(97,97,97,1)" stroke="none" points="19,-50 18,-52 18,-50" />
     <polygon fill="rgba(97,97,97,1)" stroke="none" points="18,-50 18,-52 17,-51" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="6,36 6,49 12,32" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="6,36 4,32 6,49" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="6,49 4,32 4,41" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-15,-14 -4,-4 -12,-12" />
-    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-27,-8 -5,-3 -15,-14" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-21,-11 -10,-8 -15,-14" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-15,-14 -5,-3 -5,-3" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-15,-14 -5,-3 -4,-4" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="18,-50 17,-51 0,-49" />
     <polygon fill="rgba(90,90,90,1)" stroke="none" points="-19,-50 -18,-51 -19,-51" />
     <polygon fill="rgba(81,81,81,1)" stroke="none" points="-19,-50 -19,-51 -20,-50" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="27,-8 31,-13 21,-11" />
     <polygon fill="rgba(50,50,50,1)" stroke="none" points="20,-48 20,-48 20,-49" />
     <polygon fill="rgba(51,51,51,1)" stroke="none" points="-20,-49 -20,-48 -21,-48" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-15,11 -20,15 -8,15" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-8,15 -20,15 -13,19" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="20,-49 21,-48 20,-48" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="20,-48 21,-48 21,-47" />
     <polygon fill="rgba(97,97,97,1)" stroke="none" points="-19,-50 -18,-51 -18,-51" />
@@ -2945,6 +3157,8 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="7,-8 10,-9 3,10" />
     <polygon fill="rgba(119,119,119,1)" stroke="none" points="7,-8 7,-11 10,-9" />
     <polygon fill="rgba(119,119,119,1)" stroke="none" points="10,-9 7,-11 10,-12" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-26,4 -15,11 -15,2" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-27,-5 -26,4 -15,2" />
     <polygon fill="rgba(64,64,64,1)" stroke="none" points="20,-49 21,-48 20,-49" />
     <polygon fill="rgba(64,64,64,1)" stroke="none" points="20,-49 21,-48 21,-48" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,10 8,-9 4,-8" />
@@ -3005,6 +3219,8 @@
     <polygon fill="rgba(119,119,119,1)" stroke="none" points="0,-8 2,-36 0,-36" />
     <polygon fill="rgba(94,94,94,1)" stroke="none" points="-20,-49 -19,-50 -19,-50" />
     <polygon fill="rgba(87,87,87,1)" stroke="none" points="-20,-49 -19,-50 -20,-48" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="15,13 27,1 15,8" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="15,8 27,1 27,-5" />
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="4,-7 3,10 0,-7" />
     <polygon fill="rgba(115,115,115,1)" stroke="none" points="0,-7 0,-10 4,-7" />
     <polygon fill="rgba(115,115,115,1)" stroke="none" points="4,-7 0,-10 4,-11" />
@@ -3055,6 +3271,8 @@
     <polygon fill="rgba(91,91,91,1)" stroke="none" points="20,-49 20,-48 20,-48" />
     <polygon fill="rgba(91,91,91,1)" stroke="none" points="20,-48 20,-48 20,-47" />
     <polygon fill="rgba(118,118,118,1)" stroke="none" points="0,42 0,10 -1,10" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,26 15,19 15,13" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,26 4,32 15,19" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="4,-11 2,-4 7,-11" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="7,-11 2,-4 3,-4" />
     <polygon fill="rgba(97,97,97,1)" stroke="none" points="19,-49 19,-48 20,-49" />
@@ -3063,6 +3281,8 @@
     <polygon fill="rgba(84,84,84,1)" stroke="none" points="-21,-48 -21,-46 -20,-48" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-6,-11 -3,-4 -2,-4" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="-6,-11 -2,-4 -3,-10" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="10,-9 16,-6 21,-11" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="21,-11 16,-6 27,-8" />
     <polygon fill="rgba(99,99,99,1)" stroke="none" points="18,-49 19,-48 19,-49" />
     <polygon fill="rgba(99,99,99,1)" stroke="none" points="19,-49 19,-48 19,-48" />
     <polygon fill="rgba(100,100,100,1)" stroke="none" points="0,-49 19,-48 18,-49" />
@@ -3076,6 +3296,8 @@
     <polygon fill="rgba(131,131,131,1)" stroke="none" points="12,32 11,29 12,30" />
     <polygon fill="rgba(84,84,84,1)" stroke="none" points="-20,-48 -21,-46 -20,-47" />
     <polygon fill="rgba(92,92,92,1)" stroke="none" points="-20,-48 -20,-47 -20,-49" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-16,-5 -10,-8 -21,-11" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-27,-8 -16,-5 -21,-11" />
     <polygon fill="rgba(92,92,92,1)" stroke="none" points="-20,-49 -20,-47 -20,-47" />
     <polygon fill="rgba(97,97,97,1)" stroke="none" points="-20,-49 -20,-47 -19,-49" />
     <polygon fill="rgba(190,190,190,1)" stroke="none" points="0,-10 1,-5 4,-11" />
@@ -3121,6 +3343,7 @@
     <polygon fill="rgba(70,70,70,1)" stroke="none" points="21,-45 21,-44 21,-46" />
     <polygon fill="rgba(81,81,81,1)" stroke="none" points="21,-45 21,-46 20,-45" />
     <polygon fill="rgba(81,81,81,1)" stroke="none" points="20,-45 21,-46 21,-47" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-3,10 -13,19 -3,26" />
     <polygon fill="rgba(72,72,72,1)" stroke="none" points="-21,-46 -21,-45 -20,-44" />
     <polygon fill="rgba(72,72,72,1)" stroke="none" points="-20,-44 -21,-45 -21,-44" />
     <polygon fill="rgba(90,90,90,1)" stroke="none" points="20,-45 21,-47 20,-46" />
@@ -3134,6 +3357,11 @@
     <polygon fill="rgba(101,101,101,1)" stroke="none" points="18,-47 19,-48 19,-48" />
     <polygon fill="rgba(92,92,92,1)" stroke="none" points="-20,-45 -20,-47 -21,-46" />
     <polygon fill="rgba(83,83,83,1)" stroke="none" points="-20,-45 -21,-46 -20,-44" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="-27,-5 -10,-1 -3,10" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-3,10 -7,0 -27,-5" />
+    <polygon fill="rgba(131,131,131,1)" stroke="none" points="3,10 8,0 27,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="15,2 15,8 27,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="27,-5 10,-2 3,10" />
     <polygon fill="rgba(98,98,98,1)" stroke="none" points="-20,-45 -20,-47 -20,-47" />
     <polygon fill="rgba(92,92,92,1)" stroke="none" points="-20,-45 -20,-47 -20,-45" />
     <polygon fill="rgba(101,101,101,1)" stroke="none" points="-19,-46 -19,-47 -20,-47" />
@@ -3143,10 +3371,14 @@
     <polygon fill="rgba(101,101,101,1)" stroke="none" points="-19,-46 -19,-47 -19,-46" />
     <polygon fill="rgba(72,72,72,1)" stroke="none" points="-20,-44 -21,-44 -20,-44" />
     <polygon fill="rgba(70,70,70,1)" stroke="none" points="21,-44 21,-44 21,-45" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="10,-9 5,-3 16,-6" />
     <polygon fill="rgba(79,79,79,1)" stroke="none" points="21,-45 20,-43 21,-44" />
     <polygon fill="rgba(79,79,79,1)" stroke="none" points="21,-44 20,-43 20,-43" />
+    <polygon fill="rgba(190,190,190,1)" stroke="none" points="-16,-5 -5,-3 -10,-8" />
     <polygon fill="rgba(89,89,89,1)" stroke="none" points="20,-45 20,-44 21,-45" />
     <polygon fill="rgba(89,89,89,1)" stroke="none" points="21,-45 20,-44 20,-43" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,21 15,13 15,8" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,21 3,26 15,13" />
     <polygon fill="rgba(81,81,81,1)" stroke="none" points="-20,-44 -20,-43 -20,-44" />
     <polygon fill="rgba(97,97,97,1)" stroke="none" points="20,-46 19,-44 20,-45" />
     <polygon fill="rgba(97,97,97,1)" stroke="none" points="20,-45 19,-44 20,-44" />
@@ -3200,6 +3432,8 @@
     <polygon fill="rgba(104,104,104,1)" stroke="none" points="19,-44 18,-43 20,-44" />
     <polygon fill="rgba(104,104,104,1)" stroke="none" points="20,-44 18,-43 18,-43" />
     <polygon fill="rgba(103,103,103,1)" stroke="none" points="18,-45 17,-44 18,-45" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-15,2 -15,11 -3,10" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="-3,10 -15,11 -8,15" />
     <polygon fill="rgba(107,107,107,1)" stroke="none" points="19,-45 18,-44 19,-44" />
     <polygon fill="rgba(107,107,107,1)" stroke="none" points="19,-44 18,-44 18,-43" />
     <polygon fill="rgba(103,103,103,1)" stroke="none" points="18,-45 17,-44 17,-44" />
@@ -3217,6 +3451,8 @@
     <polygon fill="rgba(108,108,108,1)" stroke="none" points="-17,-43 -18,-45 -18,-45" />
     <polygon fill="rgba(108,108,108,1)" stroke="none" points="-17,-43 -18,-45 -18,-43" />
     <polygon fill="rgba(95,95,95,1)" stroke="none" points="18,-41 19,-41 19,-42" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,15 15,8 15,2" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,15 3,21 15,8" />
     <polygon fill="rgba(95,95,95,1)" stroke="none" points="17,-41 18,-41 19,-42" />
     <polygon fill="rgba(104,104,104,1)" stroke="none" points="17,-41 19,-42 17,-41" />
     <polygon fill="rgba(104,104,104,1)" stroke="none" points="17,-41 19,-42 18,-43" />
@@ -3354,6 +3590,7 @@
     <polygon fill="rgba(110,110,110,1)" stroke="none" points="-12,-38 -15,-39 -15,-39" />
     <polygon fill="rgba(53,53,53,1)" stroke="none" points="-2,-6 -3,-6 -2,-6" />
     <polygon fill="rgba(57,57,57,1)" stroke="none" points="-2,-6 -3,-6 -4,-5" />
+    <polygon fill="rgba(100,100,100,1)" stroke="none" points="3,10 3,15 15,2" />
     <polygon fill="rgba(115,115,115,1)" stroke="none" points="14,-41 12,-41 12,-41" />
     <polygon fill="rgba(120,120,120,1)" stroke="none" points="14,-41 12,-41 15,-41" />
     <polygon fill="rgba(121,121,121,1)" stroke="none" points="15,-41 13,-40 15,-40" />

--- a/tests/obj2.test.ts
+++ b/tests/obj2.test.ts
@@ -13,6 +13,7 @@ test("OBJ rendering from remote url", async () => {
           z: 0,
         },
         drawBoundingBox: true,
+        maxFaceArea: 1,
         objUrl:
           "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=6ef04b62f1e945518af209609f65fa6f&pn=C110153&cachebust_origin=",
         // scaleObjToBox: true,


### PR DESCRIPTION
## Summary
- support optional `maxFaceArea` on `Box`
- subdivide STL/OBJ triangles and box quads when `maxFaceArea` provided
- test `maxFaceArea` using `obj2.test.ts` and update snapshot

## Testing
- `bun test tests/obj2.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/obj2.test.ts`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68730190c16c832e9f248c3e398fec6a