### PR TITLE
feat: add 3mf model loading

### DIFF
--- a/examples/dragrotate/dragrotate06-3mf.page.tsx
+++ b/examples/dragrotate/dragrotate06-3mf.page.tsx
@@ -1,0 +1,31 @@
+import DragRotate from "./DragRotate"
+
+const scene = {
+  boxes: [
+    {
+      center: { x: 0, y: 0, z: 0 },
+      size: { x: 10, y: 10, z: 10 },
+      color: "rgba(100,149,237,0.8)",
+      threeMfUrl: "https://github.com/3MFConsortium/3mf-samples/raw/refs/heads/master/examples/core/heartgears.3mf",
+      scaleThreeMfToBox: true,
+    },
+  ],
+  camera: {
+    position: { x: -15, y: 15, z: -15 },
+    lookAt: { x: 0, y: 0, z: 0 },
+  },
+} as const
+
+export default function Page() {
+  return (
+    <DragRotate
+      scene={scene as any}
+      opt={{
+        showGrid: true,
+        showAxes: true,
+        showOrigin: true,
+        backgroundColor: "white",
+      }}
+    />
+  )
+}

--- a/examples/dragrotate/dragrotate06-3mf.page.tsx
+++ b/examples/dragrotate/dragrotate06-3mf.page.tsx
@@ -6,7 +6,7 @@ const scene = {
       center: { x: 0, y: 0, z: 0 },
       size: { x: 10, y: 10, z: 10 },
       color: "rgba(100,149,237,0.8)",
-      threeMfUrl: "https://github.com/3MFConsortium/3mf-samples/raw/refs/heads/master/examples/core/heartgears.3mf",
+      threeMfUrl: "https://misc-assets-cors.seve.workers.dev/heartgears.3mf",
       scaleThreeMfToBox: true,
     },
   ],

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,3 +21,5 @@ export { renderScene } from "./render-svg"
 export { loadSTL } from "./loaders/stl"
 // Re-export OBJ loader
 export { loadOBJ } from "./loaders/obj"
+// Re-export 3MF loader
+export { load3MF } from "./loaders/threemf"

--- a/lib/loaders/threemf.ts
+++ b/lib/loaders/threemf.ts
@@ -1,0 +1,100 @@
+import type { Point3, STLMesh, Triangle } from "../types"
+import { unzipSync } from "fflate"
+import { XMLParser } from "fast-xml-parser"
+
+const threeMfCache = new Map<string, STLMesh>()
+
+export async function load3MF(url: string): Promise<STLMesh> {
+  if (threeMfCache.has(url)) {
+    return threeMfCache.get(url)!
+  }
+
+  const response = await fetch(url)
+  const buffer = await response.arrayBuffer()
+  const files = unzipSync(new Uint8Array(buffer))
+  const modelFile = files["3D/3dmodel.model"]
+  if (!modelFile) throw new Error("3MF model file not found")
+  const modelXml = new TextDecoder().decode(modelFile)
+  const mesh = parse3MF(modelXml)
+  threeMfCache.set(url, mesh)
+  return mesh
+}
+
+function parse3MF(xml: string): STLMesh {
+  const parser = new XMLParser({ ignoreAttributes: false })
+  const json = parser.parse(xml)
+  const vertexData =
+    json?.model?.resources?.object?.mesh?.vertices?.vertex ?? []
+  const vertices: Point3[] = vertexData.map((v: any) => ({
+    x: parseFloat(v["@_x"]),
+    y: parseFloat(v["@_y"]),
+    z: parseFloat(v["@_z"]),
+  }))
+
+  const triangleData =
+    json?.model?.resources?.object?.mesh?.triangles?.triangle ?? []
+  const triangles: Triangle[] = triangleData.map((t: any) => {
+    const v1 = vertices[parseInt(t["@_v1"])]!
+    const v2 = vertices[parseInt(t["@_v2"])]!
+    const v3 = vertices[parseInt(t["@_v3"])]!
+    const edge1 = { x: v2.x - v1.x, y: v2.y - v1.y, z: v2.z - v1.z }
+    const edge2 = { x: v3.x - v1.x, y: v3.y - v1.y, z: v3.z - v1.z }
+    const normal = {
+      x: edge1.y * edge2.z - edge1.z * edge2.y,
+      y: edge1.z * edge2.x - edge1.x * edge2.z,
+      z: -(edge1.x * edge2.y - edge1.y * edge2.x),
+    }
+    return { vertices: [v1, v2, v3], normal }
+  })
+
+  const rotatedTriangles = triangles.map((tri) => ({
+    ...tri,
+    vertices: tri.vertices.map((v) => ({
+      x: v.x,
+      y: -v.z,
+      z: v.y,
+    })) as [Point3, Point3, Point3],
+    normal: {
+      x: tri.normal.x,
+      y: -tri.normal.z,
+      z: tri.normal.y,
+    },
+  }))
+
+  return {
+    triangles: rotatedTriangles,
+    boundingBox: calculateBoundingBox(rotatedTriangles),
+  }
+}
+
+function calculateBoundingBox(triangles: Triangle[]): {
+  min: Point3
+  max: Point3
+} {
+  if (triangles.length === 0) {
+    return { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } }
+  }
+
+  let minX = Infinity
+  let minY = Infinity
+  let minZ = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let maxZ = -Infinity
+
+  for (const tri of triangles) {
+    for (const v of tri.vertices) {
+      if (v.x < minX) minX = v.x
+      if (v.y < minY) minY = v.y
+      if (v.z < minZ) minZ = v.z
+      if (v.x > maxX) maxX = v.x
+      if (v.y > maxY) maxY = v.y
+      if (v.z > maxZ) maxZ = v.z
+    }
+  }
+
+  return {
+    min: { x: minX, y: minY, z: minZ },
+    max: { x: maxX, y: maxY, z: maxZ },
+  }
+}

--- a/lib/mesh.ts
+++ b/lib/mesh.ts
@@ -5,7 +5,7 @@ export function scaleAndPositionMesh(
   mesh: STLMesh,
   box: Box,
   scaleToBox: boolean,
-  modelType: "stl" | "obj",
+  modelType: "stl" | "obj" | "3mf",
 ): Point3[] {
   const { boundingBox } = mesh
   const meshCenter = scale(add(boundingBox.min, boundingBox.max), 0.5)
@@ -20,6 +20,8 @@ export function scaleAndPositionMesh(
         p = rotLocal(p, box.stlRotation)
       if (modelType === "obj" && box.objRotation)
         p = rotLocal(p, box.objRotation)
+      if (modelType === "3mf" && box.threeMfRotation)
+        p = rotLocal(p, box.threeMfRotation)
       if (!centerModel) p = add(p, meshCenter)
       rotatedVerts.push(p)
     }
@@ -59,6 +61,7 @@ export function scaleAndPositionMesh(
     }
     if (box.stlPosition) t = add(t, box.stlPosition)
     if (box.objPosition) t = add(t, box.objPosition)
+    if (box.threeMfPosition) t = add(t, box.threeMfPosition)
     if (box.rotation) t = rotLocal(t, box.rotation)
     t = add(t, box.center)
     transformedVertices.push(t)

--- a/lib/render-elements.ts
+++ b/lib/render-elements.ts
@@ -1,6 +1,7 @@
 import type { Point3, Color, Box, Camera, Scene, STLMesh } from "./types"
 import { loadSTL } from "./loaders/stl"
 import { loadOBJ } from "./loaders/obj"
+import { load3MF } from "./loaders/threemf"
 import { add, sub, dot, cross, scale, len, norm, rotLocal } from "./vec3"
 import { colorToCss, shadeByNormal } from "./color"
 import { scaleAndPositionMesh } from "./mesh"
@@ -90,6 +91,7 @@ export async function buildRenderElements(
   // Load STL meshes for boxes that have stlUrl
   const stlMeshes = new Map<string, STLMesh>()
   const objMeshes = new Map<string, STLMesh>()
+  const threeMfMeshes = new Map<string, STLMesh>()
   for (const box of scene.boxes) {
     if (box.stlUrl && !stlMeshes.has(box.stlUrl)) {
       try {
@@ -105,6 +107,14 @@ export async function buildRenderElements(
         objMeshes.set(box.objUrl, mesh)
       } catch (error) {
         console.warn(`Failed to load OBJ from ${box.objUrl}:`, error)
+      }
+    }
+    if (box.threeMfUrl && !threeMfMeshes.has(box.threeMfUrl)) {
+      try {
+        const mesh = await load3MF(box.threeMfUrl)
+        threeMfMeshes.set(box.threeMfUrl, mesh)
+      } catch (error) {
+        console.warn(`Failed to load 3MF from ${box.threeMfUrl}:`, error)
       }
     }
   }
@@ -202,6 +212,43 @@ export async function buildRenderElements(
               box.color ?? triangle.color ?? "gray",
               faceNormal,
             ),
+            stroke: false,
+          })
+        }
+      }
+    } else if (box.threeMfUrl && threeMfMeshes.has(box.threeMfUrl)) {
+      const mesh = threeMfMeshes.get(box.threeMfUrl)!
+      const transformedVertices = scaleAndPositionMesh(
+        mesh,
+        box,
+        box.scaleThreeMfToBox ?? false,
+        "3mf",
+      )
+
+      for (let i = 0; i < mesh.triangles.length; i++) {
+        const vertexStart = i * 3
+
+        const v0w = transformedVertices[vertexStart]!
+        const v1w = transformedVertices[vertexStart + 1]!
+        const v2w = transformedVertices[vertexStart + 2]!
+
+        const v0c = toCam(v0w, scene.camera)
+        const v1c = toCam(v1w, scene.camera)
+        const v2c = toCam(v2w, scene.camera)
+
+        const v0p = proj(v0c, W, H, focal)
+        const v1p = proj(v1c, W, H, focal)
+        const v2p = proj(v2c, W, H, focal)
+
+        if (v0p && v1p && v2p) {
+          const edge1 = sub(v1c, v0c)
+          const edge2 = sub(v2c, v0c)
+          const faceNormal = cross(edge1, edge2)
+
+          faces.push({
+            pts: [v0p, v1p, v2p],
+            cam: [v0c, v1c, v2c],
+            fill: shadeByNormal(box.color ?? "gray", faceNormal),
             stroke: false,
           })
         }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -35,6 +35,12 @@ export interface Box {
   objPosition?: Point3
   /** When true, fit/normalize OBJ mesh to the box dimensions */
   scaleObjToBox?: boolean
+  // 3MF support
+  threeMfUrl?: string
+  threeMfRotation?: Point3
+  threeMfPosition?: Point3
+  /** When true, fit/normalize 3MF mesh to the box dimensions */
+  scaleThreeMfToBox?: boolean
 }
 
 export interface Camera {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,9 @@
     "react-dom": "^19.1.0",
     "tsup": "^8.5.0",
     "vite": "^7.0.4"
+  },
+  "dependencies": {
+    "fast-xml-parser": "^5.2.5",
+    "fflate": "^0.8.2"
   }
 }

--- a/tests/__snapshots__/threemf1.snap.svg
+++ b/tests/__snapshots__/threemf1.snap.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="-200 -200 400 400">  <g stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+    <polygon fill="rgba(196,0,0,1)" stroke="none" points="0,-71 70,-40 0,0" />
+    <polygon fill="rgba(196,0,0,1)" stroke="none" points="-70,-40 0,-71 0,0" />
+    <polygon fill="rgba(255,34,34,1)" stroke="none" points="70,-40 -70,-40 0,0" />
+    <polygon fill="rgba(196,0,0,1)" stroke="none" points="0,-71 70,-40 -70,-40" />
+  </g>
+</svg>

--- a/tests/threemf1.test.ts
+++ b/tests/threemf1.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "bun:test"
+import { renderScene } from "../lib"
+import { zipSync, strToU8 } from "fflate"
+
+function create3mfDataUrl(): string {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources>
+    <object id="1" type="model">
+      <mesh>
+        <vertices>
+          <vertex x="0" y="0" z="0"/>
+          <vertex x="1" y="0" z="0"/>
+          <vertex x="0" y="1" z="0"/>
+          <vertex x="0" y="0" z="1"/>
+        </vertices>
+        <triangles>
+          <triangle v1="0" v2="1" v3="2"/>
+          <triangle v1="0" v2="1" v3="3"/>
+          <triangle v1="1" v2="2" v3="3"/>
+          <triangle v1="2" v2="0" v3="3"/>
+        </triangles>
+      </mesh>
+    </object>
+  </resources>
+  <build>
+    <item objectid="1"/>
+  </build>
+</model>`
+  const data = zipSync({ "3D/3dmodel.model": strToU8(xml) })
+  const base64 = Buffer.from(data).toString("base64")
+  return `data:application/octet-stream;base64,${base64}`
+}
+
+const pyramid3mf = create3mfDataUrl()
+
+test("3MF rendering", async () => {
+  const scene = {
+    boxes: [
+      {
+        center: { x: 0, y: 0, z: 0 },
+        size: { x: 2, y: 2, z: 2 },
+        color: "red" as const,
+        threeMfUrl: pyramid3mf,
+        scaleThreeMfToBox: true,
+      },
+    ],
+    camera: {
+      position: { x: 5, y: 5, z: 5 },
+      lookAt: { x: 0, y: 0, z: 0 },
+    },
+  }
+
+  const svg = await renderScene(scene)
+  expect(svg).toContain("<svg")
+  expect(svg).toContain("</svg>")
+  expect(svg).toContain("polygon")
+
+  await expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- add 3MF mesh loader and export
- integrate 3MF meshes into renderer and types
- test 3MF model rendering

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/threemf1.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689b902c4e24832e8047630d5fcf56a8