### PR TITLE
feat: add 3mf model loader

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,3 +21,5 @@ export { renderScene } from "./render-svg"
 export { loadSTL } from "./loaders/stl"
 // Re-export OBJ loader
 export { loadOBJ } from "./loaders/obj"
+// Re-export 3MF loader
+export { load3MF } from "./loaders/3mf"

--- a/lib/loaders/3mf.ts
+++ b/lib/loaders/3mf.ts
@@ -1,0 +1,102 @@
+import type { Point3, STLMesh, Triangle } from "../types"
+import { unzipSync, strFromU8 } from "fflate"
+
+const mfCache = new Map<string, STLMesh>()
+
+export async function load3MF(url: string): Promise<STLMesh> {
+  if (mfCache.has(url)) return mfCache.get(url)!
+  const response = await fetch(url)
+  const buffer = await response.arrayBuffer()
+  const mesh = parse3MF(buffer)
+  mfCache.set(url, mesh)
+  return mesh
+}
+
+function parse3MF(buffer: ArrayBuffer): STLMesh {
+  const data = new Uint8Array(buffer)
+  const files = unzipSync(data)
+  const modelFile = files["3D/3dmodel.model"]
+  if (!modelFile) throw new Error("3MF model file not found")
+  const xmlText = strFromU8(modelFile)
+
+  const vertexRegex =
+    /<vertex[^>]*x="([^"]+)"[^>]*y="([^"]+)"[^>]*z="([^"]+)"[^>]*>/g
+  const vertices: Point3[] = []
+  let match: RegExpExecArray | null
+  while ((match = vertexRegex.exec(xmlText))) {
+    vertices.push({
+      x: parseFloat(match[1]!),
+      y: parseFloat(match[2]!),
+      z: parseFloat(match[3]!),
+    })
+  }
+
+  const triangleRegex =
+    /<triangle[^>]*v1="([^"]+)"[^>]*v2="([^"]+)"[^>]*v3="([^"]+)"[^>]*>/g
+  const triangles: Triangle[] = []
+  while ((match = triangleRegex.exec(xmlText))) {
+    const v1 = parseInt(match[1]!)
+    const v2 = parseInt(match[2]!)
+    const v3 = parseInt(match[3]!)
+    const a = vertices[v1]!
+    const b = vertices[v2]!
+    const c = vertices[v3]!
+    const edge1 = { x: b.x - a.x, y: b.y - a.y, z: b.z - a.z }
+    const edge2 = { x: c.x - a.x, y: c.y - a.y, z: c.z - a.z }
+    const normal = {
+      x: edge1.y * edge2.z - edge1.z * edge2.y,
+      y: edge1.z * edge2.x - edge1.x * edge2.z,
+      z: edge1.x * edge2.y - edge1.y * edge2.x,
+    }
+    triangles.push({ vertices: [a, b, c], normal })
+  }
+
+  // Rotate -90 degrees around X to convert Z-up to Y-up
+  const rotatedTriangles = triangles.map((triangle) => ({
+    ...triangle,
+    vertices: triangle.vertices.map((v) => ({
+      x: v.x,
+      y: -v.z,
+      z: v.y,
+    })) as [Point3, Point3, Point3],
+    normal: {
+      x: triangle.normal.x,
+      y: -triangle.normal.z,
+      z: triangle.normal.y,
+    },
+  }))
+
+  return {
+    triangles: rotatedTriangles,
+    boundingBox: calculateBoundingBox(rotatedTriangles),
+  }
+}
+
+function calculateBoundingBox(triangles: Triangle[]): {
+  min: Point3
+  max: Point3
+} {
+  if (triangles.length === 0) {
+    return { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } }
+  }
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity
+  let maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity
+  for (const tri of triangles) {
+    for (const v of tri.vertices) {
+      if (v.x < minX) minX = v.x
+      if (v.y < minY) minY = v.y
+      if (v.z < minZ) minZ = v.z
+      if (v.x > maxX) maxX = v.x
+      if (v.y > maxY) maxY = v.y
+      if (v.z > maxZ) maxZ = v.z
+    }
+  }
+  return {
+    min: { x: minX, y: minY, z: minZ },
+    max: { x: maxX, y: maxY, z: maxZ },
+  }
+}

--- a/lib/mesh.ts
+++ b/lib/mesh.ts
@@ -5,7 +5,7 @@ export function scaleAndPositionMesh(
   mesh: STLMesh,
   box: Box,
   scaleToBox: boolean,
-  modelType: "stl" | "obj",
+  modelType: "stl" | "obj" | "3mf",
 ): Point3[] {
   const { boundingBox } = mesh
   const meshCenter = scale(add(boundingBox.min, boundingBox.max), 0.5)
@@ -20,6 +20,8 @@ export function scaleAndPositionMesh(
         p = rotLocal(p, box.stlRotation)
       if (modelType === "obj" && box.objRotation)
         p = rotLocal(p, box.objRotation)
+      if (modelType === "3mf" && box.threeMfRotation)
+        p = rotLocal(p, box.threeMfRotation)
       if (!centerModel) p = add(p, meshCenter)
       rotatedVerts.push(p)
     }
@@ -59,6 +61,7 @@ export function scaleAndPositionMesh(
     }
     if (box.stlPosition) t = add(t, box.stlPosition)
     if (box.objPosition) t = add(t, box.objPosition)
+    if (box.threeMfPosition) t = add(t, box.threeMfPosition)
     if (box.rotation) t = rotLocal(t, box.rotation)
     t = add(t, box.center)
     transformedVertices.push(t)

--- a/lib/render-elements.ts
+++ b/lib/render-elements.ts
@@ -1,6 +1,7 @@
 import type { Point3, Color, Box, Camera, Scene, STLMesh } from "./types"
 import { loadSTL } from "./loaders/stl"
 import { loadOBJ } from "./loaders/obj"
+import { load3MF } from "./loaders/3mf"
 import { add, sub, dot, cross, scale, len, norm, rotLocal } from "./vec3"
 import { colorToCss, shadeByNormal } from "./color"
 import { scaleAndPositionMesh } from "./mesh"
@@ -90,6 +91,7 @@ export async function buildRenderElements(
   // Load STL meshes for boxes that have stlUrl
   const stlMeshes = new Map<string, STLMesh>()
   const objMeshes = new Map<string, STLMesh>()
+  const mfMeshes = new Map<string, STLMesh>()
   for (const box of scene.boxes) {
     if (box.stlUrl && !stlMeshes.has(box.stlUrl)) {
       try {
@@ -105,6 +107,14 @@ export async function buildRenderElements(
         objMeshes.set(box.objUrl, mesh)
       } catch (error) {
         console.warn(`Failed to load OBJ from ${box.objUrl}:`, error)
+      }
+    }
+    if (box.threeMfUrl && !mfMeshes.has(box.threeMfUrl)) {
+      try {
+        const mesh = await load3MF(box.threeMfUrl)
+        mfMeshes.set(box.threeMfUrl, mesh)
+      } catch (error) {
+        console.warn(`Failed to load 3MF from ${box.threeMfUrl}:`, error)
       }
     }
   }
@@ -202,6 +212,44 @@ export async function buildRenderElements(
               box.color ?? triangle.color ?? "gray",
               faceNormal,
             ),
+            stroke: false,
+          })
+        }
+      }
+    } else if (box.threeMfUrl && mfMeshes.has(box.threeMfUrl)) {
+      const mesh = mfMeshes.get(box.threeMfUrl)!
+      const transformedVertices = scaleAndPositionMesh(
+        mesh,
+        box,
+        box.scaleThreeMfToBox ?? false,
+        "3mf",
+      )
+
+      for (let i = 0; i < mesh.triangles.length; i++) {
+        const triangle = mesh.triangles[i]
+        const vertexStart = i * 3
+
+        const v0w = transformedVertices[vertexStart]!
+        const v1w = transformedVertices[vertexStart + 1]!
+        const v2w = transformedVertices[vertexStart + 2]!
+
+        const v0c = toCam(v0w, scene.camera)
+        const v1c = toCam(v1w, scene.camera)
+        const v2c = toCam(v2w, scene.camera)
+
+        const v0p = proj(v0c, W, H, focal)
+        const v1p = proj(v1c, W, H, focal)
+        const v2p = proj(v2c, W, H, focal)
+
+        if (v0p && v1p && v2p) {
+          const edge1 = sub(v1c, v0c)
+          const edge2 = sub(v2c, v0c)
+          const normal = cross(edge1, edge2)
+          const baseColor = box.color ?? "gray"
+          faces.push({
+            pts: [v0p, v1p, v2p],
+            cam: [v0c, v1c, v2c],
+            fill: shadeByNormal(baseColor, normal),
             stroke: false,
           })
         }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -35,6 +35,12 @@ export interface Box {
   objPosition?: Point3
   /** When true, fit/normalize OBJ mesh to the box dimensions */
   scaleObjToBox?: boolean
+  // 3MF support
+  threeMfUrl?: string
+  threeMfRotation?: Point3
+  threeMfPosition?: Point3
+  /** When true, fit/normalize 3MF mesh to the box dimensions */
+  scaleThreeMfToBox?: boolean
 }
 
 export interface Camera {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "react-dom": "^19.1.0",
     "tsup": "^8.5.0",
     "vite": "^7.0.4"
+  },
+  "dependencies": {
+    "fflate": "^0.8.2"
   }
 }

--- a/tests/__snapshots__/threemf.snap.svg
+++ b/tests/__snapshots__/threemf.snap.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="-200 -200 400 400">  <g stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+    <polygon fill="rgba(196,0,0,1)" stroke="none" points="0,-33 65,0 -65,0" />
+  </g>
+</svg>

--- a/tests/threemf.test.ts
+++ b/tests/threemf.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test"
+import { renderScene } from "../lib"
+
+const pyramid3MF =
+  "data:application/octet-stream;base64,UEsDBBQAAAAIAOqYDFu2wAHOCgEAAB8CAAAQABwAM0QvM2Rtb2RlbC5tb2RlbFVUCQAD55CbaOeQm2h1eAsAAQQAAAAABAAAAACNkE1ugzAQhfecwpp9GCCqVEWG7HKBNgcgZlJc+SeyDSI9fQ1O2qaoUjeW3uib5zeP7yet2EjOS2tqKPMCGBlhO2neaji+HjbPsG8yrm1Hig1Ghhq0VEpqCuSAxe2dameWzOb4sgyMr6EP4bJD9KIn3fpcS+Gst+eQC6tx2+nWDOdWhMHFf1BYR1gV5RMWFTQZY9yRt4MT5GcVtT29kwhMdjEisHC9UIwxR4IEREST7+8iynhSkF8GP4Y0samGeOZ1eT/mF/+gyn9RyatcUxzXKXhwMvalfiW7T9lYLoZjtTiO2xqqR8vVPsfv0zmmppYS8aFFfhqk6m6YDKRZQlOnmDZuTLScy22yT1BLAwQUAAAACADsmAxbKoKq17AAAADhAAAAEwAcAFtDb250ZW50X1R5cGVzXS54bWxVVAkAA+yQm2jskJtodXgLAAEEAAAAAAQAAAAALY5NroJAEIT3nGLSWwODvsQYA7jw5wR6gM7QIJHpmTCN0du/Rl1WqvLVVx1efjRPmtIQuIZ1UYIhdqEduK/hdr3kOzg0WXV9R0pGt5xquIvEvbXJ3cljKkIk1qYLk0fROPU2ontgT3ZTllvrAgux5LIwoMmMqU7U4TyKOb+0+V770NII5vgdL381YIzj4FB0YJ/cFj7lP3Lx13rkuUMn86SuueYFsFIRsCpsP8ZN9g9QSwECHgMUAAAACADqmAxbtsABzgoBAAAfAgAAEAAYAAAAAAABAAAApIEAAAAAM0QvM2Rtb2RlbC5tb2RlbFVUBQAD55CbaHV4CwABBAAAAAAEAAAAAFBLAQIeAxQAAAAIAOyYDFsqgqrXsAAAAOEAAAATABgAAAAAAAEAAACkgVQBAABbQ29udGVudF9UeXBlc10ueG1sVVQFAAPskJtodXgLAAEEAAAAAAQAAAAAUEsFBgAAAAACAAIArwAAAFECAAAAAA=="
+
+test("3MF rendering", async () => {
+  const scene = {
+    boxes: [
+      {
+        center: { x: 0, y: 0, z: 0 },
+        size: { x: 2, y: 2, z: 2 },
+        color: "red" as const,
+        threeMfUrl: pyramid3MF,
+        scaleThreeMfToBox: true,
+      },
+    ],
+    camera: {
+      position: { x: 5, y: 5, z: 5 },
+      lookAt: { x: 0, y: 0, z: 0 },
+    },
+  }
+
+  const svg = await renderScene(scene)
+  expect(svg).toContain("<svg")
+  expect(svg).toContain("</svg>")
+  expect(svg).toContain("polygon")
+
+  await expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- add 3MF model loader and integrate with rendering pipeline
- extend box options to position and scale 3MF meshes
- test rendering of 3MF models

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test`


------
https://chatgpt.com/codex/tasks/task_b_689b902c4e24832e8047630d5fcf56a8