### PR TITLE
feat: support colors in 3mf loader

### DIFF
--- a/lib/render-elements.ts
+++ b/lib/render-elements.ts
@@ -227,6 +227,7 @@ export async function buildRenderElements(
 
       for (let i = 0; i < mesh.triangles.length; i++) {
         const vertexStart = i * 3
+        const triangle = mesh.triangles[i]!
 
         const v0w = transformedVertices[vertexStart]!
         const v1w = transformedVertices[vertexStart + 1]!
@@ -248,7 +249,10 @@ export async function buildRenderElements(
           faces.push({
             pts: [v0p, v1p, v2p],
             cam: [v0c, v1c, v2c],
-            fill: shadeByNormal(box.color ?? "gray", faceNormal),
+            fill: shadeByNormal(
+              box.color ?? triangle.color ?? "gray",
+              faceNormal,
+            ),
             stroke: false,
           })
         }

--- a/tests/__snapshots__/threemf1.snap.svg
+++ b/tests/__snapshots__/threemf1.snap.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="-200 -200 400 400">  <g stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
-    <polygon fill="rgba(196,0,0,1)" stroke="none" points="0,-71 70,-40 0,0" />
-    <polygon fill="rgba(196,0,0,1)" stroke="none" points="-70,-40 0,-71 0,0" />
-    <polygon fill="rgba(255,34,34,1)" stroke="none" points="70,-40 -70,-40 0,0" />
+    <polygon fill="rgba(0,196,0,1)" stroke="none" points="0,-71 70,-40 0,0" />
+    <polygon fill="rgba(196,196,0,1)" stroke="none" points="-70,-40 0,-71 0,0" />
+    <polygon fill="rgba(34,34,255,1)" stroke="none" points="70,-40 -70,-40 0,0" />
     <polygon fill="rgba(196,0,0,1)" stroke="none" points="0,-71 70,-40 -70,-40" />
   </g>
 </svg>

--- a/tests/threemf1.test.ts
+++ b/tests/threemf1.test.ts
@@ -1,11 +1,17 @@
 import { test, expect } from "bun:test"
-import { renderScene } from "../lib"
+import { renderScene, load3MF } from "../lib"
 import { zipSync, strToU8 } from "fflate"
 
 function create3mfDataUrl(): string {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
   <resources>
+    <basematerials id="2">
+      <base name="red" displaycolor="#FF0000FF"/>
+      <base name="green" displaycolor="#00FF00FF"/>
+      <base name="blue" displaycolor="#0000FFFF"/>
+      <base name="yellow" displaycolor="#FFFF00FF"/>
+    </basematerials>
     <object id="1" type="model">
       <mesh>
         <vertices>
@@ -15,10 +21,10 @@ function create3mfDataUrl(): string {
           <vertex x="0" y="0" z="1"/>
         </vertices>
         <triangles>
-          <triangle v1="0" v2="1" v3="2"/>
-          <triangle v1="0" v2="1" v3="3"/>
-          <triangle v1="1" v2="2" v3="3"/>
-          <triangle v1="2" v2="0" v3="3"/>
+          <triangle v1="0" v2="1" v3="2" pid="2" p1="0" p2="0" p3="0"/>
+          <triangle v1="0" v2="1" v3="3" pid="2" p1="1" p2="1" p3="1"/>
+          <triangle v1="1" v2="2" v3="3" pid="2" p1="2" p2="2" p3="2"/>
+          <triangle v1="2" v2="0" v3="3" pid="2" p1="3" p2="3" p3="3"/>
         </triangles>
       </mesh>
     </object>
@@ -35,12 +41,14 @@ function create3mfDataUrl(): string {
 const pyramid3mf = create3mfDataUrl()
 
 test("3MF rendering", async () => {
+  const mesh = await load3MF(pyramid3mf)
+  expect(mesh.triangles[0]!.color).toEqual([255, 0, 0, 1])
+
   const scene = {
     boxes: [
       {
         center: { x: 0, y: 0, z: 0 },
         size: { x: 2, y: 2, z: 2 },
-        color: "red" as const,
         threeMfUrl: pyramid3mf,
         scaleThreeMfToBox: true,
       },


### PR DESCRIPTION
## Summary
- parse 3MF basematerial colors and assign them to mesh triangles
- render 3MF meshes with their triangle colors
- test 3MF color handling and update snapshot

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/threemf1.test.ts`
- `bun test tests/threemf1.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_689bac4354c8832ea6eb157a0ac164dc