### PR TITLE
fix: normalize encoded face image sources

### DIFF
--- a/lib/render-elements.ts
+++ b/lib/render-elements.ts
@@ -1,18 +1,32 @@
-import type { Point3, Color, Box, Camera, Scene, STLMesh } from "./types"
-import { loadSTL } from "./loaders/stl"
-import { loadOBJ } from "./loaders/obj"
-import { load3MF } from "./loaders/threemf"
-import { add, sub, dot, cross, scale, len, norm, rotLocal } from "./vec3"
-import { colorToCss, shadeByNormal } from "./color"
-import { scaleAndPositionMesh } from "./mesh"
-import { FACES, EDGES, TOP, verts } from "./geometry"
 import { affineMatrix } from "./affine"
+import { colorToCss, shadeByNormal } from "./color"
+import { EDGES, FACES, TOP, verts } from "./geometry"
+import { loadOBJ } from "./loaders/obj"
+import { loadSTL } from "./loaders/stl"
+import { load3MF } from "./loaders/threemf"
+import { scaleAndPositionMesh } from "./mesh"
+import type { Box, Camera, Color, Point3, STLMesh, Scene } from "./types"
+import { add, cross, dot, len, norm, rotLocal, scale, sub } from "./vec3"
 
 function fmt(n: number): string {
   return Math.round(n).toString()
 }
 function fmtPrecise(n: number): string {
   return (Math.round(n * 100) / 100).toString()
+}
+
+function encodeBase64(value: string): string {
+  if (typeof btoa === "function") return btoa(value)
+  return Buffer.from(value).toString("base64")
+}
+
+function normalizeFaceImageHref(href: string): string {
+  const trimmedHref = href.trim()
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmedHref)) return trimmedHref
+  if (/^<svg[\s>]/i.test(trimmedHref)) {
+    return `data:image/svg+xml;base64,${encodeBase64(trimmedHref)}`
+  }
+  return `data:image/png;base64,${trimmedHref}`
 }
 
 /*────────────── Camera & Projection ─────────────*/
@@ -291,7 +305,7 @@ export async function buildRenderElements(
         if (pts.every(Boolean)) {
           const dst = pts as [Point3, Point3, Point3, Point3]
           const cz = Math.max(...TOP.map((i) => vc[i]!.z))
-          const href = box.faceImages.top
+          const href = normalizeFaceImageHref(box.faceImages.top)
 
           // Assign unique texture ID
           if (!texId.has(href)) {
@@ -462,8 +476,8 @@ export async function buildRenderElements(
       for (let k = 1; k < list.length; k++) {
         const f = list[k]!
         // classify each vertex
-        let pos = 0,
-          neg = 0
+        let pos = 0
+        let neg = 0
         const d: number[] = []
         for (const v of f.cam) {
           const dist = dot(normal, sub(v!, p0))

--- a/tests/topimage-encoded.test.ts
+++ b/tests/topimage-encoded.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { renderScene } from "lib"
+import { CHECKER_2x2 } from "./fixtures/checkerboard"
+
+test("top face image accepts an encoded png without a data url prefix", async () => {
+  const encodedImage = CHECKER_2x2.replace("data:image/png;base64,", "")
+
+  const svg = await renderScene({
+    boxes: [
+      {
+        center: { x: 0, y: 0, z: 5 },
+        size: { x: 2, y: 2, z: 2 },
+        color: "gray",
+        faceImages: {
+          top: encodedImage,
+        },
+      },
+    ],
+    camera: { position: { x: 0, y: 3, z: 0 }, lookAt: { x: 0, y: 0, z: 5 } },
+  })
+
+  expect(svg).toContain(`href="data:image/png;base64,${encodedImage}"`)
+})


### PR DESCRIPTION
Fixes #3

@algora-pbc /claim #3

## Summary
- Accept bare encoded PNG strings for `Box.faceImages.top` by normalizing them to `data:image/png;base64,...`.
- Preserve existing data/URL image hrefs and support inline SVG markup by encoding it as `data:image/svg+xml;base64,...`.
- Add regression coverage for bare encoded top-face PNGs.

## Verification
- `bun run build`
- `bun x biome check lib\render-elements.ts tests\topimage-encoded.test.ts`
- Direct render verification with `bun` confirmed encoded face images are normalized.
- `git diff --check`

Note: `bun test tests\topimage-encoded.test.ts` is blocked on this Windows machine because the repo preload imports `bun-match-svg`/`looks-same`, and `sharp` fails to install/link locally.