### PR TITLE
feat: cull fully hidden polygons with RBush

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ renderScene(
 )
 ```
 
+### `cullHiddenPolygons`
+
+Set `cullHiddenPolygons` to `true` to skip faces whose 2D projection is completely
+covered by closer opaque polygons. Coverage uses an [RBush](https://github.com/mourner/rbush)
+index plus a boolean clip (`isPolygonCoveredByOtherPolygons`). Off by default so
+dense meshes keep their current paint order.
+
+```ts
+renderScene(
+  {
+    /* ... scene definition ... */
+  },
+  {
+    cullHiddenPolygons: true,
+  },
+)
+```
+
 ### `showAxes`
 
 Set `showAxes` to `true` to draw a small XYZ axis guide (about 8% of the SVG size)

--- a/lib/color.ts
+++ b/lib/color.ts
@@ -28,6 +28,12 @@ export function colorToCss(c: Color): string {
   return `rgba(${Math.round(r)},${Math.round(g)},${Math.round(b)},${a})`
 }
 
+/** True when a CSS fill would hide whatever is painted underneath it. */
+export function isOpaqueFill(fill: string): boolean {
+  if (!fill || fill === "none" || fill === "transparent") return false
+  return colorToRGBA(fill)[3] >= 1 - 1e-6
+}
+
 export function colorToRGBA(c: Color): RGBA {
   if (Array.isArray(c)) return c
   const s = c.trim().toLowerCase()

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,6 +17,11 @@ export type {
 // Re-export the main render function
 export { renderScene } from "./render-svg"
 
+export {
+  areaOfPolygonCoveredByOtherPolygons,
+  isPolygonCoveredByOtherPolygons,
+} from "./polygon-visibility"
+
 // Re-export STL loader
 export { loadSTL } from "./loaders/stl"
 // Re-export OBJ loader

--- a/lib/polygon-visibility.ts
+++ b/lib/polygon-visibility.ts
@@ -1,0 +1,179 @@
+import RBush from "rbush"
+import polygonClipping from "polygon-clipping"
+
+export type Point2 = { x: number; y: number }
+
+const PIXEL_AREA_THRESHOLD = 1
+/** Skip expensive boolean unions when a face overlaps too many neighbors. */
+const MAX_BOOLEAN_OCCLUDERS = 16
+
+type BBox = {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+type OccluderItem = BBox & { pts: Point2[] }
+
+function closeRing(pts: Point2[]): [number, number][] {
+  const ring: [number, number][] = pts.map((p) => [p.x, p.y])
+  if (ring.length === 0) return ring
+  const first = ring[0]!
+  const last = ring[ring.length - 1]!
+  if (first[0] !== last[0] || first[1] !== last[1]) {
+    ring.push([first[0], first[1]])
+  }
+  if (signedRingArea(ring) < 0) {
+    ring.reverse()
+  }
+  return ring
+}
+
+function signedRingArea(ring: [number, number][]): number {
+  let area = 0
+  for (let i = 0; i < ring.length - 1; i++) {
+    const a = ring[i]!
+    const b = ring[i + 1]!
+    area += a[0] * b[1] - b[0] * a[1]
+  }
+  return area / 2
+}
+
+function polygonArea(pts: Point2[]): number {
+  if (pts.length < 3) return 0
+  return Math.abs(signedRingArea(closeRing(pts)))
+}
+
+function multiPolygonArea(geom: [number, number][][][] | undefined): number {
+  if (!geom) return 0
+  let area = 0
+  for (const polygon of geom) {
+    const outer = polygon[0]
+    if (!outer) continue
+    area += Math.abs(signedRingArea(outer))
+    for (let i = 1; i < polygon.length; i++) {
+      area -= Math.abs(signedRingArea(polygon[i]!))
+    }
+  }
+  return area
+}
+
+function toGeom(pts: Point2[]): [number, number][][] {
+  return [closeRing(pts)]
+}
+
+export function boundsOfPolygon(pts: Point2[]): BBox {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const p of pts) {
+    if (p.x < minX) minX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.x > maxX) maxX = p.x
+    if (p.y > maxY) maxY = p.y
+  }
+  return { minX, minY, maxX, maxY }
+}
+
+function pointInPolygon(point: Point2, pts: Point2[]): boolean {
+  let inside = false
+  for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+    const a = pts[i]!
+    const b = pts[j]!
+    const intersects =
+      a.y > point.y !== b.y > point.y &&
+      point.x < ((b.x - a.x) * (point.y - a.y)) / (b.y - a.y) + a.x
+    if (intersects) inside = !inside
+  }
+  return inside
+}
+
+function polygonContainsPolygon(outer: Point2[], inner: Point2[]): boolean {
+  if (outer.length < 3 || inner.length < 3) return false
+  return inner.every((point) => pointInPolygon(point, outer))
+}
+
+/**
+ * Area of `subject` that lies under the union of `otherPolygons`.
+ */
+export function areaOfPolygonCoveredByOtherPolygons(
+  subject: Point2[],
+  otherPolygons: Point2[][],
+): number {
+  const subjectArea = polygonArea(subject)
+  if (subjectArea === 0 || otherPolygons.length === 0) return 0
+  const occluders = otherPolygons.filter((pts) => pts.length >= 3)
+  if (occluders.some((occluder) => polygonContainsPolygon(occluder, subject))) {
+    return subjectArea
+  }
+  try {
+    const leftover = polygonClipping.difference(
+      toGeom(subject),
+      ...occluders.map(toGeom),
+    )
+    return Math.max(0, subjectArea - multiPolygonArea(leftover))
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * True when `subject` is completely hidden by `otherPolygons`, or would
+ * change fewer than about one SVG pixel if it were omitted.
+ */
+export function isPolygonCoveredByOtherPolygons(
+  subject: Point2[],
+  otherPolygons: Point2[][],
+): boolean {
+  const occluders = otherPolygons.filter((pts) => pts.length >= 3)
+  if (occluders.length === 0) return false
+  if (occluders.some((occluder) => polygonContainsPolygon(occluder, subject))) {
+    return true
+  }
+  if (occluders.length > MAX_BOOLEAN_OCCLUDERS) return false
+  try {
+    const leftover = polygonClipping.difference(
+      toGeom(subject),
+      ...occluders.map(toGeom),
+    )
+    return multiPolygonArea(leftover) <= PIXEL_AREA_THRESHOLD
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Painter-order items (last = closest / drawn on top). Drops items whose
+ * 2D projection is completely covered by closer opaque polygons.
+ */
+export function cullOccludedPolygons<T>(
+  items: T[],
+  getPoints: (item: T) => Point2[],
+  isOpaqueOccluder: (item: T) => boolean,
+): T[] {
+  const tree = new RBush<OccluderItem>()
+  const kept: T[] = []
+
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i]!
+    const pts = getPoints(item)
+    const bbox = boundsOfPolygon(pts)
+    const candidates = tree.search(bbox).map((entry) => entry.pts)
+    if (
+      candidates.length > 0 &&
+      isPolygonCoveredByOtherPolygons(pts, candidates)
+    ) {
+      continue
+    }
+
+    kept.push(item)
+    if (isOpaqueOccluder(item) && pts.length >= 3) {
+      tree.insert({ ...bbox, pts })
+    }
+  }
+
+  kept.reverse()
+  return kept
+}

--- a/lib/render-elements.ts
+++ b/lib/render-elements.ts
@@ -3,10 +3,11 @@ import { loadSTL } from "./loaders/stl"
 import { loadOBJ } from "./loaders/obj"
 import { load3MF } from "./loaders/threemf"
 import { add, sub, dot, cross, scale, len, norm, rotLocal } from "./vec3"
-import { colorToCss, shadeByNormal } from "./color"
+import { colorToCss, isOpaqueFill, shadeByNormal } from "./color"
 import { scaleAndPositionMesh } from "./mesh"
 import { FACES, EDGES, TOP, verts } from "./geometry"
 import { affineMatrix } from "./affine"
+import { cullOccludedPolygons } from "./polygon-visibility"
 
 function fmt(n: number): string {
   return Math.round(n).toString()
@@ -67,7 +68,12 @@ type RenderElement =
 
 export async function buildRenderElements(
   scene: Scene,
-  opt: { width?: number; height?: number; backgroundColor?: Color } = {},
+  opt: {
+    width?: number
+    height?: number
+    backgroundColor?: Color
+    cullHiddenPolygons?: boolean
+  } = {},
 ): Promise<{
   width: number
   height: number
@@ -561,9 +567,17 @@ export async function buildRenderElements(
   }
 
   const orderedFaces = sortFacesBSP(faces, W, H, focal)
+  const visibleFaces =
+    opt.cullHiddenPolygons === true
+      ? cullOccludedPolygons(
+          orderedFaces,
+          (face) => face.pts,
+          (face) => isOpaqueFill(face.fill) || faceToImg.has(face),
+        )
+      : orderedFaces
 
   const elements: RenderElement[] = []
-  for (const f of orderedFaces) {
+  for (const f of visibleFaces) {
     const img = faceToImg.get(f)
     if (img) {
       elements.push({ type: "image", data: img })

--- a/lib/render-svg.ts
+++ b/lib/render-svg.ts
@@ -16,6 +16,11 @@ export async function renderScene(
     showAxes?: boolean
     showOrigin?: boolean
     showGrid?: boolean
+    /**
+     * Drop 2D polygons completely hidden by closer opaque faces.
+     * Uses an RBush index plus boolean clipping. Off by default.
+     */
+    cullHiddenPolygons?: boolean
     grid?: {
       /** world-space grid cell size (default = 1)            */ cellSize?: number
       /** plane on which to draw the grid (default = "xz")   */ plane?:
@@ -36,6 +41,7 @@ export async function renderScene(
     width: opt.width,
     height: opt.height,
     backgroundColor: opt.backgroundColor,
+    cullHiddenPolygons: opt.cullHiddenPolygons,
   })
 
   const out: string[] = []

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/bun": "latest",
+    "@types/rbush": "^4.0.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "bun-match-svg": "^0.0.12",
@@ -31,6 +32,8 @@
   },
   "dependencies": {
     "fast-xml-parser": "^5.2.5",
-    "fflate": "^0.8.2"
+    "fflate": "^0.8.2",
+    "polygon-clipping": "^0.15.7",
+    "rbush": "^4.0.1"
   }
 }

--- a/tests/polygon-visibility.test.ts
+++ b/tests/polygon-visibility.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test"
+import {
+  areaOfPolygonCoveredByOtherPolygons,
+  isPolygonCoveredByOtherPolygons,
+  renderScene,
+} from "lib"
+
+function countPolygons(svg: string): number {
+  return svg.match(/<polygon /g)?.length ?? 0
+}
+
+test("a polygon inside a larger polygon is fully covered", () => {
+  const inner = [
+    { x: 10, y: 10 },
+    { x: 20, y: 10 },
+    { x: 20, y: 20 },
+    { x: 10, y: 20 },
+  ]
+  const outer = [
+    { x: 0, y: 0 },
+    { x: 40, y: 0 },
+    { x: 40, y: 40 },
+    { x: 0, y: 40 },
+  ]
+
+  expect(isPolygonCoveredByOtherPolygons(inner, [outer])).toBe(true)
+  expect(areaOfPolygonCoveredByOtherPolygons(inner, [outer])).toBe(100)
+})
+
+test("two side-by-side polygons do not cover a polygon that spans the gap", () => {
+  const subject = [
+    { x: 0, y: 0 },
+    { x: 30, y: 0 },
+    { x: 30, y: 10 },
+    { x: 0, y: 10 },
+  ]
+  const left = [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ]
+  const right = [
+    { x: 20, y: 0 },
+    { x: 30, y: 0 },
+    { x: 30, y: 10 },
+    { x: 20, y: 10 },
+  ]
+
+  expect(isPolygonCoveredByOtherPolygons(subject, [left, right])).toBe(false)
+})
+
+test("two adjacent polygons together cover a spanning polygon", () => {
+  const subject = [
+    { x: 0, y: 0 },
+    { x: 20, y: 0 },
+    { x: 20, y: 10 },
+    { x: 0, y: 10 },
+  ]
+  const left = [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ]
+  const right = [
+    { x: 10, y: 0 },
+    { x: 20, y: 0 },
+    { x: 20, y: 10 },
+    { x: 10, y: 10 },
+  ]
+
+  expect(isPolygonCoveredByOtherPolygons(subject, [left, right])).toBe(true)
+})
+
+test("renderScene drops faces of an opaque box hidden behind a closer wall", async () => {
+  const scene = {
+    boxes: [
+      {
+        center: { x: 0, y: 0, z: 4 },
+        size: { x: 6, y: 6, z: 0.4 },
+        color: "red",
+      },
+      {
+        center: { x: 0, y: 0, z: 8 },
+        size: { x: 1, y: 1, z: 1 },
+        color: "blue",
+      },
+    ],
+    camera: {
+      position: { x: 0, y: 0, z: 0 },
+      lookAt: { x: 0, y: 0, z: 6 },
+    },
+  }
+
+  const withHiddenFaces = await renderScene(scene, {
+    cullHiddenPolygons: false,
+  })
+  const culled = await renderScene(scene, { cullHiddenPolygons: true })
+
+  expect(countPolygons(culled)).toBeLessThan(countPolygons(withHiddenFaces))
+  expect(countPolygons(culled)).toBeGreaterThan(0)
+})

--- a/types/polygon-clipping.d.ts
+++ b/types/polygon-clipping.d.ts
@@ -1,0 +1,17 @@
+declare module "polygon-clipping" {
+  type Pair = [number, number]
+  type Ring = Pair[]
+  type Polygon = Ring[]
+  type MultiPolygon = Polygon[]
+  type Geom = Polygon | MultiPolygon
+
+  interface PolygonClipping {
+    intersection(geom: Geom, ...geoms: Geom[]): MultiPolygon
+    union(geom: Geom, ...geoms: Geom[]): MultiPolygon
+    xor(geom: Geom, ...geoms: Geom[]): MultiPolygon
+    difference(subjectGeom: Geom, ...clipGeoms: Geom[]): MultiPolygon
+  }
+
+  const polygonClipping: PolygonClipping
+  export default polygonClipping
+}


### PR DESCRIPTION
## Summary

Adds the polygon-visibility pass requested in https://github.com/tscircuit/simple-3d-svg/issues/38.

- `isPolygonCoveredByOtherPolygons` / `areaOfPolygonCoveredByOtherPolygons` for 2D coverage
- RBush index of closer opaque faces, then a boolean clip so a polygon covered by the *union* of neighbors is dropped
- `renderScene(scene, { cullHiddenPolygons: true })` to turn it on (off by default so existing snapshots and dense STL/OBJ scenes stay as they are)
- Fail-open when a face overlaps too many neighbors (avoids a clip timeout on large meshes)

## Test plan

- [x] `bun test tests/polygon-visibility.test.ts`
- [x] `bun test` (existing snapshots unchanged)
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit`