### PR TITLE
feat: render jscad-planner objects via scene.jscadObjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ renderScene({
       color: [0, 128, 255, 0.9],
     },
   ],
+  jscadObjects: [
+    {
+      jscad: {
+        type: "subtract",
+        shapes: [
+          { type: "cuboid", size: [1, 1, 1] },
+          {
+            type: "translate",
+            vector: [0.5, 0.35, 0.35],
+            shape: { type: "cuboid", size: [1, 1, 1] },
+          },
+        ],
+      },
+      color: "#4682b4",
+    },
+  ],
   camera: { position: { x: -3, y: 4, z: 0 }, lookAt: { x: 0, y: 0, z: 6 } },
 })
 // "<svg>...</svg>"
@@ -47,6 +63,7 @@ for visual snapshot testing.
 
 - To correctly transform text for 3D, you need a perspective transform. However, the SVG spec only provides affine transforms. As a result, the text on the top of boxes will always look slighly "off".
 - You can project an image onto the top face of a box by providing `faceImages.top` with a data URI. The renderer uses two clipped images to achieve a perspective-correct mapping.
+- `jscadObjects` accepts [jscad-planner](https://github.com/tscircuit/jscad-planner) operations (`cuboid`, `union`, `translate`, …). Coordinates are world-space, the same frame as `boxes` (Y-up). Each object is triangulated and shaded by its `color`.
 
 ## Advanced Configuration
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,6 +10,7 @@ export type {
   Box,
   Camera,
   Scene,
+  JscadObject,
   Triangle,
   STLMesh,
 } from "./types"
@@ -23,3 +24,5 @@ export { loadSTL } from "./loaders/stl"
 export { loadOBJ } from "./loaders/obj"
 // Re-export 3MF loader
 export { load3MF } from "./loaders/threemf"
+// Re-export jscad-planner loader
+export { loadJscadOperation } from "./loaders/jscad"

--- a/lib/loaders/jscad.ts
+++ b/lib/loaders/jscad.ts
@@ -1,0 +1,141 @@
+import * as jscadModeling from "@jscad/modeling"
+import { geometries } from "@jscad/modeling"
+import { executeJscadOperations } from "jscad-planner"
+import type { JscadOperation } from "jscad-planner"
+import type { Point3, STLMesh, Triangle } from "../types"
+
+type JscadPolygon = {
+  vertices: Array<number[] | Float32Array>
+}
+
+function asGeomList(result: unknown): unknown[] {
+  if (result == null) return []
+  if (Array.isArray(result)) return result.flatMap(asGeomList)
+  return [result]
+}
+
+function geom3ToMesh(geometry: unknown): STLMesh {
+  const polygons = geometries.geom3.toPolygons(
+    geometry as never,
+  ) as JscadPolygon[]
+  const triangles: Triangle[] = []
+  let minX = Infinity
+  let minY = Infinity
+  let minZ = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let maxZ = -Infinity
+
+  const updateBounds = (p: Point3) => {
+    if (p.x < minX) minX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.z < minZ) minZ = p.z
+    if (p.x > maxX) maxX = p.x
+    if (p.y > maxY) maxY = p.y
+    if (p.z > maxZ) maxZ = p.z
+  }
+
+  for (const poly of polygons) {
+    if (!poly || poly.vertices.length < 3) continue
+    const verts: Point3[] = poly.vertices.map((v) => ({
+      x: Number(v[0]),
+      y: Number(v[1]),
+      z: Number(v[2]),
+    }))
+    const base = verts[0]!
+    const next = verts[1]!
+    const next2 = verts[2]!
+    const ab = {
+      x: next.x - base.x,
+      y: next.y - base.y,
+      z: next.z - base.z,
+    }
+    const ac = {
+      x: next2.x - base.x,
+      y: next2.y - base.y,
+      z: next2.z - base.z,
+    }
+    const cross = {
+      x: ab.y * ac.z - ab.z * ac.y,
+      y: ab.z * ac.x - ab.x * ac.z,
+      z: ab.x * ac.y - ab.y * ac.x,
+    }
+    const length = Math.sqrt(cross.x ** 2 + cross.y ** 2 + cross.z ** 2) || 1
+    const normal = {
+      x: cross.x / length,
+      y: cross.y / length,
+      z: cross.z / length,
+    }
+
+    for (let i = 1; i < verts.length - 1; i++) {
+      const v1 = verts[i]!
+      const v2 = verts[i + 1]!
+      updateBounds(base)
+      updateBounds(v1)
+      updateBounds(v2)
+      triangles.push({
+        vertices: [base, v1, v2],
+        normal,
+      })
+    }
+  }
+
+  if (!triangles.length) {
+    return {
+      triangles,
+      boundingBox: {
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: 0, y: 0, z: 0 },
+      },
+    }
+  }
+
+  return {
+    triangles,
+    boundingBox: {
+      min: { x: minX, y: minY, z: minZ },
+      max: { x: maxX, y: maxY, z: maxZ },
+    },
+  }
+}
+
+export function loadJscadOperation(operation: JscadOperation): STLMesh {
+  const result = executeJscadOperations(jscadModeling as never, operation)
+  const meshes = asGeomList(result).map(geom3ToMesh)
+  if (meshes.length === 1) return meshes[0]!
+
+  const triangles = meshes.flatMap((mesh) => mesh.triangles)
+  if (!triangles.length) {
+    return {
+      triangles,
+      boundingBox: {
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: 0, y: 0, z: 0 },
+      },
+    }
+  }
+
+  let minX = Infinity
+  let minY = Infinity
+  let minZ = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let maxZ = -Infinity
+  for (const mesh of meshes) {
+    const { min, max } = mesh.boundingBox
+    if (min.x < minX) minX = min.x
+    if (min.y < minY) minY = min.y
+    if (min.z < minZ) minZ = min.z
+    if (max.x > maxX) maxX = max.x
+    if (max.y > maxY) maxY = max.y
+    if (max.z > maxZ) maxZ = max.z
+  }
+
+  return {
+    triangles,
+    boundingBox: {
+      min: { x: minX, y: minY, z: minZ },
+      max: { x: maxX, y: maxY, z: maxZ },
+    },
+  }
+}

--- a/lib/render-elements.ts
+++ b/lib/render-elements.ts
@@ -2,6 +2,7 @@ import type { Point3, Color, Box, Camera, Scene, STLMesh } from "./types"
 import { loadSTL } from "./loaders/stl"
 import { loadOBJ } from "./loaders/obj"
 import { load3MF } from "./loaders/threemf"
+import { loadJscadOperation } from "./loaders/jscad"
 import { add, sub, dot, cross, scale, len, norm, rotLocal } from "./vec3"
 import { colorToCss, shadeByNormal } from "./color"
 import { scaleAndPositionMesh } from "./mesh"
@@ -88,11 +89,13 @@ export async function buildRenderElements(
   let clipSeq = 0
   const texId = new Map<string, string>()
 
+  const boxes = scene.boxes ?? []
+
   // Load STL meshes for boxes that have stlUrl
   const stlMeshes = new Map<string, STLMesh>()
   const objMeshes = new Map<string, STLMesh>()
   const threeMfMeshes = new Map<string, STLMesh>()
-  for (const box of scene.boxes) {
+  for (const box of boxes) {
     if (box.stlUrl && !stlMeshes.has(box.stlUrl)) {
       try {
         const mesh = await loadSTL(box.stlUrl)
@@ -119,7 +122,7 @@ export async function buildRenderElements(
     }
   }
 
-  for (const box of scene.boxes) {
+  for (const box of boxes) {
     const bw = verts(box)
     const bc = bw.map((v) => toCam(v, scene.camera))
     const bp = bc.map((v) => proj(v, W, H, focal))
@@ -429,6 +432,37 @@ export async function buildRenderElements(
             })
           }
         }
+      }
+    }
+  }
+
+  for (const obj of scene.jscadObjects ?? []) {
+    let mesh: STLMesh
+    try {
+      mesh = loadJscadOperation(obj.jscad)
+    } catch (error) {
+      console.warn("Failed to execute jscad operation:", error)
+      continue
+    }
+
+    for (const triangle of mesh.triangles) {
+      const [v0w, v1w, v2w] = triangle.vertices
+      const v0c = toCam(v0w, scene.camera)
+      const v1c = toCam(v1w, scene.camera)
+      const v2c = toCam(v2w, scene.camera)
+
+      const v0p = proj(v0c, W, H, focal)
+      const v1p = proj(v1c, W, H, focal)
+      const v2p = proj(v2c, W, H, focal)
+
+      if (v0p && v1p && v2p) {
+        const normal = cross(sub(v1c, v0c), sub(v2c, v0c))
+        faces.push({
+          pts: [v0p, v1p, v2p],
+          cam: [v0c, v1c, v2c],
+          fill: shadeByNormal(obj.color, normal),
+          stroke: false,
+        })
       }
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+import type { JscadOperation } from "jscad-planner"
+
 // Types for simple-3d-svg
 export interface Point3 {
   x: number
@@ -49,8 +51,15 @@ export interface Camera {
   focalLength?: number
 }
 
+export interface JscadObject {
+  jscad: JscadOperation
+  color: string
+}
+
 export interface Scene {
-  boxes: Box[]
+  boxes?: Box[]
+  /** World-space solids from jscad-planner operations */
+  jscadObjects?: JscadObject[]
   camera: Camera
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "vite": "^7.0.4"
   },
   "dependencies": {
+    "@jscad/modeling": "^2.13.0",
     "fast-xml-parser": "^5.2.5",
-    "fflate": "^0.8.2"
+    "fflate": "^0.8.2",
+    "jscad-planner": "^0.0.14"
   }
 }

--- a/tests/__snapshots__/jscad-objects.snap.svg
+++ b/tests/__snapshots__/jscad-objects.snap.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="-200 -200 400 400">  <g stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+    <polygon fill="rgba(216,0,0,0.9)" stroke="none" points="19,7 21,-73 78,-36" />
+    <polygon fill="rgba(216,0,0,0.9)" stroke="none" points="19,7 78,-36 68,55" />
+    <polygon fill="rgba(203,0,0,0.9)" stroke="none" points="-62,29 19,7 68,55" />
+    <polygon fill="rgba(203,0,0,0.9)" stroke="none" points="-62,29 68,55 -25,86" />
+    <polygon fill="rgba(177,0,0,0.9)" stroke="none" points="-62,29 -70,-57 21,-73" />
+    <polygon fill="rgba(177,0,0,0.9)" stroke="none" points="-62,29 21,-73 19,7" />
+    <polygon fill="rgba(255,78,78,0.9)" stroke="none" points="-25,86 78,-36 -29,-11" />
+    <polygon fill="rgba(255,78,78,0.9)" stroke="none" points="-25,86 68,55 78,-36" />
+    <polygon fill="rgba(255,52,52,0.9)" stroke="none" points="-70,-57 78,-36 21,-73" />
+    <polygon fill="rgba(255,52,52,0.9)" stroke="none" points="-70,-57 -29,-11 78,-36" />
+    <polygon fill="rgba(255,39,39,0.9)" stroke="none" points="-62,29 -29,-11 -70,-57" />
+    <polygon fill="rgba(255,39,39,0.9)" stroke="none" points="-62,29 -25,86 -29,-11" />
+  </g>
+</svg>

--- a/tests/__snapshots__/subtract.snap.svg
+++ b/tests/__snapshots__/subtract.snap.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="-200 -200 400 400">  <g stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+    <polygon fill="rgba(56,105,145,1)" stroke="none" points="-48,24 15,7 52,42" />
+    <polygon fill="rgba(56,105,145,1)" stroke="none" points="-48,24 52,42 -19,64" />
+    <polygon fill="rgba(48,89,124,1)" stroke="none" points="-48,24 -53,-43 16,-56" />
+    <polygon fill="rgba(48,89,124,1)" stroke="none" points="-48,24 16,-56 15,7" />
+    <polygon fill="rgba(59,110,152,1)" stroke="none" points="52,42 25,17 26,-2" />
+    <polygon fill="rgba(59,110,152,1)" stroke="none" points="52,42 26,-2 53,23" />
+    <polygon fill="rgba(59,110,152,1)" stroke="none" points="25,17 15,7 15,-11 23,-4" />
+    <polygon fill="rgba(59,110,152,1)" stroke="none" points="25,17 23,-4 26,-2" />
+    <polygon fill="rgba(128,169,203,1)" stroke="none" points="18,43 52,42 53,23 19,33" />
+    <polygon fill="rgba(128,169,203,1)" stroke="none" points="18,53 52,42 18,43" />
+    <polygon fill="rgba(106,154,195,1)" stroke="none" points="19,33 26,-2 -7,6" />
+    <polygon fill="rgba(106,154,195,1)" stroke="none" points="19,33 53,23 26,-2" />
+    <polygon fill="rgba(59,110,152,1)" stroke="none" points="15,-11 16,-56 23,-4" />
+    <polygon fill="rgba(59,110,152,1)" stroke="none" points="23,-4 16,-56 27,-48 26,-2" />
+    <polygon fill="rgba(106,154,195,1)" stroke="none" points="27,-48 -12,-46 -7,-42" />
+    <polygon fill="rgba(106,154,195,1)" stroke="none" points="27,-48 16,-56 -17,-50 -12,-46" />
+    <polygon fill="rgba(128,169,203,1)" stroke="none" points="26,-2 -7,-42 -7,6" />
+    <polygon fill="rgba(128,169,203,1)" stroke="none" points="26,-2 27,-48 -7,-42" />
+    <polygon fill="rgba(59,110,152,1)" stroke="none" points="-7,-42 20,-19 19,33" />
+    <polygon fill="rgba(59,110,152,1)" stroke="none" points="-7,-42 19,33 -7,6" />
+    <polygon fill="rgba(128,169,203,1)" stroke="none" points="-19,43 18,43 19,33" />
+    <polygon fill="rgba(128,169,203,1)" stroke="none" points="-19,43 -19,64 18,53 18,43" />
+    <polygon fill="rgba(128,169,203,1)" stroke="none" points="-21,-10 19,33 20,-19" />
+    <polygon fill="rgba(128,169,203,1)" stroke="none" points="-21,-10 -19,43 19,33" />
+    <polygon fill="rgba(106,154,195,1)" stroke="none" points="-12,-46 -53,-43 -44,-34 -7,-42" />
+    <polygon fill="rgba(106,154,195,1)" stroke="none" points="-17,-50 -53,-43 -12,-46" />
+    <polygon fill="rgba(106,154,195,1)" stroke="none" points="20,-19 -44,-34 -21,-10" />
+    <polygon fill="rgba(106,154,195,1)" stroke="none" points="20,-19 -7,-42 -44,-34" />
+    <polygon fill="rgba(99,150,192,1)" stroke="none" points="-48,24 -21,-10 -53,-43" />
+    <polygon fill="rgba(99,150,192,1)" stroke="none" points="-48,24 -19,64 -21,-10" />
+  </g>
+</svg>

--- a/tests/jscad-objects.test.ts
+++ b/tests/jscad-objects.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "bun:test"
+import { renderScene } from "lib"
+
+test("jscadObjects cuboid produces shaded polygons", async () => {
+  const svg = await renderScene({
+    boxes: [],
+    jscadObjects: [
+      {
+        jscad: {
+          type: "cuboid",
+          size: [2, 2, 2],
+        },
+        color: "rgba(255, 0, 0, 0.9)",
+      },
+    ],
+    camera: { position: { x: -3, y: 4, z: 6 }, lookAt: { x: 0, y: 0, z: 0 } },
+  })
+
+  expect(svg).toContain("<svg")
+  expect(svg).toContain("</svg>")
+  expect(svg).toContain("<polygon")
+  expect((svg.match(/<polygon/g) ?? []).length).toBeGreaterThanOrEqual(6)
+  await expect(svg).toMatchSvgSnapshot(import.meta.path)
+})
+
+test("jscadObjects subtract of translated cuboids uses jscad-planner", async () => {
+  const svg = await renderScene({
+    boxes: [],
+    jscadObjects: [
+      {
+        jscad: {
+          type: "subtract",
+          shapes: [
+            { type: "cuboid", size: [2, 2, 2] },
+            {
+              type: "translate",
+              vector: [1, 0.6, 0.6],
+              shape: { type: "cuboid", size: [2, 2, 2] },
+            },
+          ],
+        },
+        color: "#4682b4",
+      },
+    ],
+    camera: {
+      position: { x: -4, y: 5, z: 8 },
+      lookAt: { x: 0, y: 0, z: 0 },
+    },
+  })
+
+  expect(svg).toContain("<polygon")
+  expect((svg.match(/<polygon/g) ?? []).length).toBeGreaterThan(12)
+  await expect(svg).toMatchSvgSnapshot(import.meta.path, "subtract")
+})


### PR DESCRIPTION
## Summary

Implements https://github.com/tscircuit/simple-3d-svg/issues/2.

- `Scene.jscadObjects?: Array<{ jscad: JscadOperation, color: string }>`
- `loadJscadOperation` runs the tree through [jscad-planner](https://github.com/tscircuit/jscad-planner) + `@jscad/modeling`, fans `geom3` polygons into triangles, and returns an `STLMesh`
- Triangles are drawn in world space (same Y-up frame as `boxes`), shaded by the object `color`
- `boxes` is optional so a scene can be jscad-only

## Test plan

- [x] `bun test tests/jscad-objects.test.ts` (cuboid snapshot + subtract CSG snapshot)
- [x] `bun test`
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit`